### PR TITLE
Constrained Python Elasticsearch version to <7.0.0 to keep it from br…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 capitains-nautilus>=1.0.2
-elasticsearch>=6.3.0
+elasticsearch>=6.3.0,<7.0.0
 MyCapytain>=2.0.0
 requests_cache>=0.4.9
 Flask>=0.12.0


### PR DESCRIPTION
…eaking with 'doc_type' param