### PR TITLE
Short regest will now be shown for formulae

### DIFF
--- a/formulae/nemo.py
+++ b/formulae/nemo.py
@@ -465,7 +465,8 @@ class NemoFormulae(Nemo):
                     "publang": str(metadata.metadata.get_single(DC.language, lang=lang)),
                     "publisher": str(metadata.metadata.get_single(DC.publisher, lang=lang)),
                     'lang': collection.lang,
-                    'citation': str(metadata.metadata.get_single(DCTERMS.bibliographicCitation, lang=lang))
+                    'citation': str(metadata.metadata.get_single(DCTERMS.bibliographicCitation, lang=lang)),
+                    "short_regest": str(metadata.metadata.get_single(DCTERMS.abstract)) if 'andecavensis' in collection.id else ''
                 },
                 "parents": self.make_parents(collection, lang=lang)
             },

--- a/templates/main/multipassage.html
+++ b/templates/main/multipassage.html
@@ -6,8 +6,7 @@
     <span class="text-center">{{ version_menu(object.objectId) }}</span>
     {% if 'elexicon' not in object.objectId %}
         {% if object.open_regest or current_user.project_team %}
-        <p class="entry-summary text-center"><button type="button" class="btn btn-link" data-toggle="modal" data-target="#{{ object.objectId|replace(':', '')|replace('.', '') }}-modal">{{ _('Regest') }}</button></p>
-        {% include "main::regest_modal.html" %}
+        {% include "main::regest_collapse.html" %}
         {% else %}
         <br>
         {% endif %}

--- a/templates/main/regest_collapse.html
+++ b/templates/main/regest_collapse.html
@@ -1,0 +1,11 @@
+<!-- The Modal Content for the Regest -->
+    {% if object.collections.current.short_regest != '' %}
+    <div class="regest-header text-center">
+        <h5 class="card-title mb-0" id="{{ object.objectId|replace(':', '')|replace('.', '') }}-modalLabel">{{object.collections.current.short_regest}}</h5><a data-toggle="collapse" aria-labelledby="{{ object.objectId|replace(':', '')|replace('.', '') }}-collapseLabel" aria-expanded="false" href="#{{ object.objectId|replace(':', '')|replace('.', '') }}-collapse">{{ _('Vollregest') }}</a>
+    </div>
+    {% else %}
+    <a data-toggle="collapse" href="#{{ object.objectId|replace(':', '')|replace('.', '') }}-collapse" aria-labelledby="{{ object.objectId|replace(':', '')|replace('.', '') }}-collapseLabel" aria-expanded="false">{{ _('Regest') }}</a>
+    {% endif %}
+    <div class="collapse" id="{{ object.objectId|replace(':', '')|replace('.', '') }}-collapse">
+        <div class="card card-body bg-light">{{object.collections.current.description}}</div>
+    </div>


### PR DESCRIPTION
The full regest has been moved to a collapse instead of a modal. This should make it easier to work with the text and the regest at the same time