### PR TITLE
Fixed an ElasticSearch TransportError

### DIFF
--- a/assets/js/advanced_search.js
+++ b/assets/js/advanced_search.js
@@ -31,7 +31,7 @@ wordSearchInput.onkeyup = function(e) {
         // - a function that sends the partial search query request to the server to be sent to elasticsearch (see showLexEntry above)
         // this is taken directly from https://blog.teamtreehouse.com/creating-autocomplete-dropdowns-datalist-element
         var word = wordSearchInput.value;
-        if(word !== ''){
+        if(word !== '' && !(word.match(/[\*\?]/))){
             previous = word;
             var request = new XMLHttpRequest();
             request.onreadystatechange = function(response) {

--- a/formulae/search/Search.py
+++ b/formulae/search/Search.py
@@ -126,6 +126,8 @@ def suggest_word_search(term, **kwargs):
 
     :return: sorted set of results
     """
+    if '*' in term or '?' in term:
+        return None
     results = []
     kwargs['fragment_size'] = 1000
     posts, total, aggs = advanced_query_index(q=term, per_page=1000, **kwargs)

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1577,6 +1577,15 @@ class TestES(Formulae_Testing):
         test_args.pop('q')
         results = suggest_word_search('ill', **test_args)
         self.assertEqual(results, expected, 'The true results should match the expected results.')
+        # Make sure that a wildcard in the search term will not call ElasticSearch but, instead, return None
+        results = suggest_word_search('*', **test_args)
+        self.assertIsNone(results, 'Autocomplete should return None when only "*" is in the search string.')
+        results = suggest_word_search('?', **test_args)
+        self.assertIsNone(results, 'Autocomplete should return None when only "*" is in the search string.')
+        results = suggest_word_search('ill*', **test_args)
+        self.assertIsNone(results, 'Autocomplete should return None when only "*" is in the search string.')
+        results = suggest_word_search('ill?', **test_args)
+        self.assertIsNone(results, 'Autocomplete should return None when only "*" is in the search string.')
 
     def test_results_sort_option(self):
         self.assertEqual(build_sort_list('urn'), 'urn')


### PR DESCRIPTION
- Made it so requests with wildcards (* or ?) are not sent to the autocomplete search function
- The problem was that it would return too many results and ES would choke