### PR TITLE
Corrected problem with simple search

### DIFF
--- a/assets/css/theme.css
+++ b/assets/css/theme.css
@@ -507,6 +507,10 @@ button.close {
     margin-top: .25rem;
 }
 
+.corpora-search-results-dropdown {
+    z-index: 1030;
+}
+
 .smallfont {
     font-size: small;
 }

--- a/formulae/search/routes.py
+++ b/formulae/search/routes.py
@@ -24,7 +24,7 @@ def r_simple_search():
                 flash(m[0] + _(' Resultate aus "Formeln" und "Urkunden" werden hier gezeigt.'))
             elif k == 'q':
                 flash(m[0] + _(' Die einfache Suche funktioniert nur mit einem Suchwort.'))
-        return redirect(url_for('.r_results', source='simple', corpus=['formulae', 'chartae'], q=g.search_form.data['q']))
+        return redirect(url_for('.r_results', source='simple', corpus='formulae+chartae', q=g.search_form.data['q']))
     data = g.search_form.data
     data['q'] = data['q'].lower()
     corpus = '+'.join(data.pop("corpus"))
@@ -57,6 +57,8 @@ def r_results():
                                    sort=request.args.get('sort', 'urn'))
         search_args = {"q": g.search_form.q.data, 'source': 'simple', 'corpus': '+'.join(corpus),
                        'sort': request.args.get('sort', 'urn')}
+        if request.args.get('old_search', None):
+            search_args.update({'old_search': True})
     else:
         posts, total, aggs = advanced_query_index(per_page=current_app.config['POSTS_PER_PAGE'], field=field,
                                                   q=request.args.get('q'),

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -2048,7 +2048,7 @@ class TestES(Formulae_Testing):
                           'Charters should automatically be search when no index is given in simple search.')
             self.assertIn('andecavensis', old_search_args['corpus'],
                           'Formulae should automatically be search when no index is given in simple search.')
-            self.client.get('/search/simple?index=&q=regnum&old_search=True', follow_redirects=True)
+            self.client.get('/results/simple?index=&q=regnum&old_search=True', follow_redirects=True)
             self.assertEqual(old_search_args['corpus'], session['previous_search_args']['corpus'],
                              'Searches made with the old_search=True argument should not change the previous_search_args.')
             self.client.get('/search/simple?index=formulae&q=', follow_redirects=True)

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -2048,7 +2048,7 @@ class TestES(Formulae_Testing):
                           'Charters should automatically be search when no index is given in simple search.')
             self.assertIn('andecavensis', old_search_args['corpus'],
                           'Formulae should automatically be search when no index is given in simple search.')
-            self.client.get('/results?source=simple&index=formulae&q=regnum&old_search=True', follow_redirects=True)
+            self.client.get('/search/results?source=simple&index=formulae&q=regnum&old_search=True', follow_redirects=True)
             self.assertEqual(old_search_args['corpus'], session['previous_search_args']['corpus'],
                              'Searches made with the old_search=True argument should not change the previous_search_args.')
             self.client.get('/search/simple?index=formulae&q=', follow_redirects=True)

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -2048,7 +2048,7 @@ class TestES(Formulae_Testing):
                           'Charters should automatically be search when no index is given in simple search.')
             self.assertIn('andecavensis', old_search_args['corpus'],
                           'Formulae should automatically be search when no index is given in simple search.')
-            self.client.get('/results/simple?index=formulae&q=regnum&old_search=True', follow_redirects=True)
+            self.client.get('/results?source=simple&index=formulae&q=regnum&old_search=True', follow_redirects=True)
             self.assertEqual(old_search_args['corpus'], session['previous_search_args']['corpus'],
                              'Searches made with the old_search=True argument should not change the previous_search_args.')
             self.client.get('/search/simple?index=formulae&q=', follow_redirects=True)

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -2048,7 +2048,7 @@ class TestES(Formulae_Testing):
                           'Charters should automatically be search when no index is given in simple search.')
             self.assertIn('andecavensis', old_search_args['corpus'],
                           'Formulae should automatically be search when no index is given in simple search.')
-            self.client.get('/results/simple?index=&q=regnum&old_search=True', follow_redirects=True)
+            self.client.get('/results/simple?index=formulae&q=regnum&old_search=True', follow_redirects=True)
             self.assertEqual(old_search_args['corpus'], session['previous_search_args']['corpus'],
                              'Searches made with the old_search=True argument should not change the previous_search_args.')
             self.client.get('/search/simple?index=formulae&q=', follow_redirects=True)


### PR DESCRIPTION
Previously if you restricted your search to a specific corpus, you could not get back to the full search. Also added a test to make sure that an empty corpus argument in simple search searches both formulae and chartae