### PR TITLE
Moved the no copy modal to the end of the HTML

### DIFF
--- a/templates/main/sub_collection.html
+++ b/templates/main/sub_collection.html
@@ -1,7 +1,5 @@
 {% extends "main::container.html" %}
 
-{% include "main::no_copy_modal.html" %}
-
 {% macro make_dates(values) %}
 
 {% if values['dating'] not in ['None', ''] %}
@@ -111,4 +109,5 @@
         </div>
 {% endif %}
 </div>
+{% include "main::no_copy_modal.html" %}
 {% endblock %}

--- a/templates/main/sub_collection_mv.html
+++ b/templates/main/sub_collection_mv.html
@@ -14,7 +14,6 @@
     {% set copy_class = '' %}
 {% endif %}
 
-{% include "main::no_copy_modal.html" %}
 
 {% block article %}
 
@@ -72,3 +71,5 @@
     </li>
     {% endfor %}
 {% endmacro %}
+
+{% include "main::no_copy_modal.html" %}

--- a/templates/main/text_container.html
+++ b/templates/main/text_container.html
@@ -23,13 +23,13 @@
     </div>
 </div>
 
-{% include "main::no_copy_modal.html" %}
-
 <div class="col hfeed right-columns" id="reading-container">
 <!-- THE TEXTS -->
 {% block texts %}
 {% endblock %}
 </div>
+
+{% include "main::no_copy_modal.html" %}
 
 <!-- THE RIGHT COLUMN -->
 <div id="sidebar_r" class="col-2 d-none d-lg-block reading-sidebar">


### PR DESCRIPTION
This will stop it from rendering before the rest of the page and flashing its message for a split second before the rest of the page renders and it disappears again