### PR TITLE
E-Lexicon search

### DIFF
--- a/assets/js/empty.js
+++ b/assets/js/empty.js
@@ -152,7 +152,8 @@ function buildSimpleUrl(qSource) {
         corpus:'',
         lemma_search:'autocomplete',
     };
-    if (searchLemmas.checked) {
+    var simpleSearchLemmas = document.getElementById('simple-lemma-checkbox');
+    if (simpleSearchLemmas.checked) {
         params.lemma_search = 'autocomplete_lemmas';
     } else {
         params.lemma_search = 'autocomplete';
@@ -216,16 +217,20 @@ function buildUrl(qSource) {
             params.lemma_search = 'False';
         }
     }
-    $('input.under-formulae').each(function(i, formula) {
-        if (formula.checked) {
-            corpus.push(formula.value);
-        }
-    })
-    $('input.under-chartae').each(function(i, charter) {
-        if (charter.checked) {
-            corpus.push(charter.value);
-        }
-    })
+    if ($('#elexiconSearchCorpus').prop('checked')) {
+        corpus = ['elexicon'];
+    } else {
+        $('input.under-formulae').each(function(i, formula) {
+            if (formula.checked) {
+                corpus.push(formula.value);
+            }
+        })
+        $('input.under-chartae').each(function(i, charter) {
+            if (charter.checked) {
+                corpus.push(charter.value);
+            }
+        })
+    }
     $('input[name="special_days"]').each(function(i, day) {
         if (day.checked) {
             special_days.push(day.value);

--- a/assets/js/empty.js
+++ b/assets/js/empty.js
@@ -216,7 +216,7 @@ function buildUrl(qSource) {
             params.lemma_search = 'False';
         }
     }
-    $('input.under-formulelexicon-search-boxae').each(function(i, formula) {
+    $('input.under-formulae').each(function(i, formula) {
         if (formula.checked) {
             corpus.push(formula.value);
         }

--- a/assets/js/empty.js
+++ b/assets/js/empty.js
@@ -216,7 +216,7 @@ function buildUrl(qSource) {
             params.lemma_search = 'False';
         }
     }
-    $('input.under-formulae').each(function(i, formula) {
+    $('input.under-formulelexicon-search-boxae').each(function(i, formula) {
         if (formula.checked) {
             corpus.push(formula.value);
         }
@@ -556,9 +556,29 @@ $(document).ready(function () {
     
     $('.simpleTextCorpus').click(function() {
         $('.simpleLexiconCorpus').prop('checked', false);
+        $('#simple-lemma-checkbox').prop('disabled', false);
     })
     
     $('.simpleLexiconCorpus').click(function() {
         $('.simpleTextCorpus').prop('checked', false);
+        $('#simple-lemma-checkbox').prop({'disabled': true, 'checked': false});
+    })
+    
+    if ($('#elexiconSimpleCheck').prop('checked')) {
+        $('#simple-lemma-checkbox').prop({'disabled': true, 'checked': false});
+    }
+    
+    $('#elexicon-search-box').keyup(function() {
+        if ($(this).val() == '') {
+            $('#elexSearchButton').addClass('disabled', true);
+        } else {
+            $('#elexSearchButton').removeClass('disabled', false);
+        }
+    })
+    
+    $('#elexSearchButton').click(function() {
+        var oldUrl = $( this ).attr("href");
+        qValue = $('#elexicon-search-box').val();
+        $( this ).attr("href", oldUrl + '&q=' + qValue.replace(' ', '+'));
     })
 })

--- a/formulae/nemo.py
+++ b/formulae/nemo.py
@@ -9,7 +9,7 @@ from rdflib.namespace import DCTERMS, DC, Namespace
 from MyCapytain.common.constants import Mimetypes
 from MyCapytain.resources.collections.capitains import XmlCapitainsReadableMetadata, XmlCapitainsCollectionMetadata
 from MyCapytain.errors import UnknownCollection
-from formulae.search.forms import SearchForm, AdvancedSearchForm
+from formulae.search.forms import SearchForm
 from formulae.search.Search import lem_highlight_to_text, POST_TAGS, PRE_TAGS
 from lxml import etree
 from .errors.handlers import e_internal_error, e_not_found_error, e_unknown_collection_error
@@ -733,8 +733,6 @@ class NemoFormulae(Nemo):
         current_parents = self.make_parents(collection, lang=lang)
         form = None
         if 'elexicon' in objectId:
-            form = AdvancedSearchForm()
-            form.corpus.choices = [('elexicon', _l('Lexikon'))]
             template = "main::elex_collection.html"
         elif 'salzburg' in objectId:
             template = "main::salzburg_collection.html"

--- a/formulae/nemo.py
+++ b/formulae/nemo.py
@@ -9,7 +9,7 @@ from rdflib.namespace import DCTERMS, DC, Namespace
 from MyCapytain.common.constants import Mimetypes
 from MyCapytain.resources.collections.capitains import XmlCapitainsReadableMetadata, XmlCapitainsCollectionMetadata
 from MyCapytain.errors import UnknownCollection
-from formulae.search.forms import SearchForm
+from formulae.search.forms import SearchForm, AdvancedSearchForm
 from formulae.search.Search import lem_highlight_to_text, POST_TAGS, PRE_TAGS
 from lxml import etree
 from .errors.handlers import e_internal_error, e_not_found_error, e_unknown_collection_error
@@ -731,7 +731,10 @@ class NemoFormulae(Nemo):
         r = OrderedDict()
         template = "main::sub_collection.html"
         current_parents = self.make_parents(collection, lang=lang)
+        form = None
         if 'elexicon' in objectId:
+            form = AdvancedSearchForm()
+            form.corpus.choices = [('elexicon', _l('Lexikon'))]
             template = "main::elex_collection.html"
         elif 'salzburg' in objectId:
             template = "main::salzburg_collection.html"
@@ -803,7 +806,8 @@ class NemoFormulae(Nemo):
                 "readable": r,
                 "parents": current_parents,
                 "parent_ids": [x['id'] for x in current_parents]
-            }
+            },
+            "form": form
         }
         return return_value
 

--- a/formulae/search/Search.py
+++ b/formulae/search/Search.py
@@ -429,12 +429,14 @@ def advanced_query_index(corpus: list = None, lemma_search: str = None, q: str =
     if 'elexicon' in corpus:
         corpus = ['elexicon']
         search_field = 'text'
+        if 'autocomplete' in lemma_search:
+            search_field = 'autocomplete'
         clauses = []
         for term in q.split():
             if '*' in term or '?' in term:
-                clauses.append({'wildcard': {'text': {'value': term}}})
+                clauses.append({'wildcard': {search_field: {'value': term}}})
             else:
-                clauses.append({'match': {'text': {'query': term, 'fuzziness': fuzziness}}})
+                clauses.append({'match': {search_field: {'query': term, 'fuzziness': fuzziness}}})
         body_template['query']['bool']['must'] = clauses
         body_template['highlight'] = {'fields': {search_field: {}},
                                       'pre_tags': [PRE_TAGS],

--- a/templates/main/elex_collection.html
+++ b/templates/main/elex_collection.html
@@ -20,13 +20,13 @@
         </div>
     </div>
     <div class="row">
-        <div class="form-group mb-2 col-3">
-            <div class="text-center search-section-label mb-0"><strong><label for="word-search-box">{{ _('Im Lexikon suchen') }}</label></strong></div>
-            <div>
-                {{ form.q(class="form-control my-0", placeholder=form.q.label.text, id="word-search-box", list="word-search-datalist", default=form.q.label.text, autocomplete="off") }} {{ form.submit(size=32, class="btn btn-lg btn-secondary", downloadId=1|random_int(10000)|string) }}
-                <datalist id="word-search-datalist">
+        <div class="mb-2 col-3">
+            <label class="sr-only" for="elexicon-search-box">{{ _('Lexikon durchsuchen') }}</label>
+            <form class="form-inline">
+                <input class="form-control" type="text" placeholder="{{ _('Lexikon durchsuchen') }}" id="elexicon-search-box" list="elexicon-search-datalist" default="{{ _('Lexikon durchsuchen') }}" autocomplete="off"> <a id="elexSearchButton" type="submit" class="btn btn-primary disabled" role="button" href="{{ url_for('search.r_results', corpus='elexicon', source='simple') }}">{{ _('Suche Durchführen') }}</a>
+                <datalist id="elexicon-search-datalist">
                 </datalist>
-            </div>
+            </form>
         </div>
     </div>
     <h4>{{ _('Gehe zu Buchstabe:') }}</h4>

--- a/templates/main/elex_collection.html
+++ b/templates/main/elex_collection.html
@@ -19,6 +19,16 @@
         <p class="mb-0">{{ _('Das e-Lexikon erläutert zentrale Begriffe aus Rechts-, Sozial- und Geistesgeschichte und macht ihre Bedeutungsentwicklung von der Spätantike bis zum Ende des frühen Mittelalters nachvollziehbar. Aufgenommen werden ausschließlich Begriffe, die in den im Langzeitvorhaben edierten Formeln verwendet werden.') }}</p>
         </div>
     </div>
+    <div class="row">
+        <div class="form-group mb-2 col-3">
+            <div class="text-center search-section-label mb-0"><strong><label for="word-search-box">{{ _('Im Lexikon suchen') }}</label></strong></div>
+            <div>
+                {{ form.q(class="form-control my-0", placeholder=form.q.label.text, id="word-search-box", list="word-search-datalist", default=form.q.label.text, autocomplete="off") }} {{ form.submit(size=32, class="btn btn-lg btn-secondary", downloadId=1|random_int(10000)|string) }}
+                <datalist id="word-search-datalist">
+                </datalist>
+            </div>
+        </div>
+    </div>
     <h4>{{ _('Gehe zu Buchstabe:') }}</h4>
     <div class="row">
         <div class="col">

--- a/templates/search/advanced_search.html
+++ b/templates/search/advanced_search.html
@@ -52,8 +52,8 @@
                                                 for="{{ choice[1] }}">{{ choice[0]|safe }}</label></li>
                                     {% endfor %}
                                     </ul>
-                            <li><input id="elexiconSearchCorpus" name="corpus" type="checkbox" value="elexicon" onclick="uncheckAllCorpora()"> <label for="elexiconSearchCorpus">{{ _('Lexikon') }}</label></li>
                         </ul>
+                        <li><input id="elexiconSearchCorpus" name="corpus" type="checkbox" value="elexicon" onclick="uncheckAllCorpora()"> <label for="elexiconSearchCorpus">{{ _('Lexikon') }}</label></li>
                     </ul>
                 </div>
                 <div class="col-xl-2 col-4">

--- a/templates/search/search_box.html
+++ b/templates/search/search_box.html
@@ -6,9 +6,9 @@
             {% for corp in g.search_form.corpus %}
             <div class="form-check form-check-inline corpus-check">
                 {% if 'elexicon' not in g.search_form.data.corpus %}
-                {% if not loop.last %}{{corp(checked="", class="simpleTextCorpus")}}{% else %}{{corp(class="simpleLexiconCorpus")}}{% endif %} {{ corp.label(class="mb-0 align-top") }}
+                {% if not loop.last %}{{corp(checked="", class="simpleTextCorpus", id=g.search_form.corpus.choices[loop.index0][0] + 'SimpleCheck')}}{% else %}{{corp(class="simpleLexiconCorpus", id="elexiconSimpleCheck")}}{% endif %} {{ corp.label(class="mb-0 align-top") }}
                 {% else %}
-                {% if not loop.last %}{{corp(class="simpleTextCorpus")}}{% else %}{{corp(checked="", class="simpleLexiconCorpus")}}{% endif %} {{ corp.label(class="mb-0 align-top") }}
+                {% if not loop.last %}{{corp(class="simpleTextCorpus", id=g.search_form.corpus.choices[loop.index0][0] + 'SimpleCheck')}}{% else %}{{corp(checked="", class="simpleLexiconCorpus", id="elexiconSimpleCheck")}}{% endif %} {{ corp.label(class="mb-0 align-top") }}
                 {% endif %}
             </div>
             {% endfor %}
@@ -20,7 +20,7 @@
         </datalist>
     </div>
     <div class="form-row justify-content-between">
-        <span id="simple-lemma-tooltip" data-toggle="tooltip" data-container="#simple-lemma-tooltip" title="{{ _('Die Lemmatasuche ist nur bei lateinischen Formeltexten möglich') }}" style="font-size: small;">{{ g.search_form.lemma_search() }} <span class="text-white p-0 align-top">{{ g.search_form.lemma_search.label(class="m-0") }}</span></span>
+        <span id="simple-lemma-tooltip" data-toggle="tooltip" data-container="#simple-lemma-tooltip" title="{{ _('Die Lemmatasuche ist nur bei lateinischen Formeltexten möglich') }}" style="font-size: small;">{{ g.search_form.lemma_search(id="simple-lemma-checkbox") }} <span class="text-white p-0 align-top">{{ g.search_form.lemma_search.label(class="m-0") }}</span></span>
         <a id="advanced-search-link-tooltip" data-toggle="tooltip" data-container="#advanced-search-link-tooltip" class="nav-link text-white p-0 text-right relative-position" href="{{ url_for('search.r_advanced_search') }}" title="{{ _('Zur Seite der erweiterten Suche') }}">{{ _('Erweiterte Suche') }}</a>
     </div>
 </form>

--- a/tests/fake_es.py
+++ b/tests/fake_es.py
@@ -48,7 +48,8 @@ class FakeElasticsearch(object):
                               'regest': ['regest text'],
                               'autocomplete_regest': ['autocomplete regest text']}
         for i, h in enumerate(resp['hits']['hits']):
-            if 'buenden' not in h['_id'] and 'freising' not in h['_id'] and 'papsturkunden_frankreich' not in h['_id']:
+            if 'buenden' not in h['_id'] and 'freising' not in h['_id'] and 'papsturkunden_frankreich' not in h['_id']\
+                    and 'elexicon' not in h['_id']:
                 resp['hits']['hits'][i]['_source']['text'] = 'some real text'
                 resp['hits']['hits'][i]['_source']['lemmas'] = 'lemma text'
                 resp['hits']['hits'][i]['_source']['autocomplete'] = 'autocomplete text'

--- a/tests/test_data/advanced_search/__mocks__/_search/all&False&&0&False&0&0&0&0&0&0&0&0&0&0&0&False&&urn&&&regest&&personenname&include&False&&advanced_req.json
+++ b/tests/test_data/advanced_search/__mocks__/_search/all&False&&0&False&0&0&0&0&0&0&0&0&0&0&0&False&&urn&&&regest&&personenname&include&False&&advanced_req.json
@@ -22,163 +22,7 @@
                   "match": {
                     "fuzzy": {
                       "lemmas": {
-                        "value": "marculfus",
-                        "fuzziness": "0"
-                      }
-                    }
-                  }
-                }
-              },
-              {
-                "span_multi": {
-                  "match": {
-                    "fuzzy": {
-                      "lemmas": {
-                        "value": "petrus",
-                        "fuzziness": "0"
-                      }
-                    }
-                  }
-                }
-              },
-              {
-                "span_multi": {
-                  "match": {
-                    "fuzzy": {
-                      "lemmas": {
-                        "value": "abiron",
-                        "fuzziness": "0"
-                      }
-                    }
-                  }
-                }
-              },
-              {
-                "span_multi": {
-                  "match": {
-                    "fuzzy": {
-                      "lemmas": {
-                        "value": "zezia",
-                        "fuzziness": "0"
-                      }
-                    }
-                  }
-                }
-              },
-              {
-                "span_multi": {
-                  "match": {
-                    "fuzzy": {
-                      "lemmas": {
-                        "value": "theudorigus",
-                        "fuzziness": "0"
-                      }
-                    }
-                  }
-                }
-              },
-              {
-                "span_multi": {
-                  "match": {
-                    "fuzzy": {
-                      "lemmas": {
-                        "value": "adam",
-                        "fuzziness": "0"
-                      }
-                    }
-                  }
-                }
-              },
-              {
-                "span_multi": {
-                  "match": {
-                    "fuzzy": {
-                      "lemmas": {
-                        "value": "martinus",
-                        "fuzziness": "0"
-                      }
-                    }
-                  }
-                }
-              },
-              {
-                "span_multi": {
-                  "match": {
-                    "fuzzy": {
-                      "lemmas": {
-                        "value": "abraham",
-                        "fuzziness": "0"
-                      }
-                    }
-                  }
-                }
-              },
-              {
-                "span_multi": {
-                  "match": {
-                    "fuzzy": {
-                      "lemmas": {
-                        "value": "moses",
-                        "fuzziness": "0"
-                      }
-                    }
-                  }
-                }
-              },
-              {
-                "span_multi": {
-                  "match": {
-                    "fuzzy": {
-                      "lemmas": {
-                        "value": "childoricus",
-                        "fuzziness": "0"
-                      }
-                    }
-                  }
-                }
-              },
-              {
-                "span_multi": {
-                  "match": {
-                    "fuzzy": {
-                      "lemmas": {
-                        "value": "dathan",
-                        "fuzziness": "0"
-                      }
-                    }
-                  }
-                }
-              },
-              {
-                "span_multi": {
-                  "match": {
-                    "fuzzy": {
-                      "lemmas": {
-                        "value": "childebertus",
-                        "fuzziness": "0"
-                      }
-                    }
-                  }
-                }
-              },
-              {
-                "span_multi": {
-                  "match": {
-                    "fuzzy": {
-                      "lemmas": {
-                        "value": "chlotharius",
-                        "fuzziness": "0"
-                      }
-                    }
-                  }
-                }
-              },
-              {
-                "span_multi": {
-                  "match": {
-                    "fuzzy": {
-                      "lemmas": {
-                        "value": "david",
+                        "value": "theodosius",
                         "fuzziness": "0"
                       }
                     }
@@ -202,7 +46,7 @@
                   "match": {
                     "fuzzy": {
                       "lemmas": {
-                        "value": "maria",
+                        "value": "honorius",
                         "fuzziness": "0"
                       }
                     }
@@ -214,7 +58,7 @@
                   "match": {
                     "fuzzy": {
                       "lemmas": {
-                        "value": "jesus",
+                        "value": "petrus",
                         "fuzziness": "0"
                       }
                     }
@@ -226,43 +70,7 @@
                   "match": {
                     "fuzzy": {
                       "lemmas": {
-                        "value": "iosoe",
-                        "fuzziness": "0"
-                      }
-                    }
-                  }
-                }
-              },
-              {
-                "span_multi": {
-                  "match": {
-                    "fuzzy": {
-                      "lemmas": {
-                        "value": "paulus",
-                        "fuzziness": "0"
-                      }
-                    }
-                  }
-                }
-              },
-              {
-                "span_multi": {
-                  "match": {
-                    "fuzzy": {
-                      "lemmas": {
-                        "value": "theodosius",
-                        "fuzziness": "0"
-                      }
-                    }
-                  }
-                }
-              },
-              {
-                "span_multi": {
-                  "match": {
-                    "fuzzy": {
-                      "lemmas": {
-                        "value": "theodorigus",
+                        "value": "abraham",
                         "fuzziness": "0"
                       }
                     }
@@ -286,6 +94,114 @@
                   "match": {
                     "fuzzy": {
                       "lemmas": {
+                        "value": "paulus",
+                        "fuzziness": "0"
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "span_multi": {
+                  "match": {
+                    "fuzzy": {
+                      "lemmas": {
+                        "value": "zezia",
+                        "fuzziness": "0"
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "span_multi": {
+                  "match": {
+                    "fuzzy": {
+                      "lemmas": {
+                        "value": "iudas",
+                        "fuzziness": "0"
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "span_multi": {
+                  "match": {
+                    "fuzzy": {
+                      "lemmas": {
+                        "value": "dathan",
+                        "fuzziness": "0"
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "span_multi": {
+                  "match": {
+                    "fuzzy": {
+                      "lemmas": {
+                        "value": "maria",
+                        "fuzziness": "0"
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "span_multi": {
+                  "match": {
+                    "fuzzy": {
+                      "lemmas": {
+                        "value": "martinus",
+                        "fuzziness": "0"
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "span_multi": {
+                  "match": {
+                    "fuzzy": {
+                      "lemmas": {
+                        "value": "abiron",
+                        "fuzziness": "0"
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "span_multi": {
+                  "match": {
+                    "fuzzy": {
+                      "lemmas": {
+                        "value": "chlotharius",
+                        "fuzziness": "0"
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "span_multi": {
+                  "match": {
+                    "fuzzy": {
+                      "lemmas": {
+                        "value": "theudorigus",
+                        "fuzziness": "0"
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "span_multi": {
+                  "match": {
+                    "fuzzy": {
+                      "lemmas": {
                         "value": "theudoricus",
                         "fuzziness": "0"
                       }
@@ -298,7 +214,43 @@
                   "match": {
                     "fuzzy": {
                       "lemmas": {
-                        "value": "honorius",
+                        "value": "childebertus",
+                        "fuzziness": "0"
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "span_multi": {
+                  "match": {
+                    "fuzzy": {
+                      "lemmas": {
+                        "value": "theodorigus",
+                        "fuzziness": "0"
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "span_multi": {
+                  "match": {
+                    "fuzzy": {
+                      "lemmas": {
+                        "value": "childoricus",
+                        "fuzziness": "0"
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "span_multi": {
+                  "match": {
+                    "fuzzy": {
+                      "lemmas": {
+                        "value": "jesus",
                         "fuzziness": "0"
                       }
                     }
@@ -322,7 +274,55 @@
                   "match": {
                     "fuzzy": {
                       "lemmas": {
-                        "value": "iudas",
+                        "value": "david",
+                        "fuzziness": "0"
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "span_multi": {
+                  "match": {
+                    "fuzzy": {
+                      "lemmas": {
+                        "value": "adam",
+                        "fuzziness": "0"
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "span_multi": {
+                  "match": {
+                    "fuzzy": {
+                      "lemmas": {
+                        "value": "moses",
+                        "fuzziness": "0"
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "span_multi": {
+                  "match": {
+                    "fuzzy": {
+                      "lemmas": {
+                        "value": "marculfus",
+                        "fuzziness": "0"
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "span_multi": {
+                  "match": {
+                    "fuzzy": {
+                      "lemmas": {
+                        "value": "iosoe",
                         "fuzziness": "0"
                       }
                     }

--- a/tests/test_data/advanced_search/__mocks__/_search/all&False&&0&False&0&0&0&0&0&0&0&0&0&0&0&False&&urn&&&regest&&personenname&include&False&&advanced_resp.json
+++ b/tests/test_data/advanced_search/__mocks__/_search/all&False&&0&False&0&0&0&0&0&0&0&0&0&0&0&False&&urn&&&regest&&personenname&include&False&&advanced_resp.json
@@ -1,5 +1,5 @@
 {
-  "took": 72,
+  "took": 63,
   "timed_out": false,
   "_shards": {
     "total": 56,

--- a/tests/test_data/advanced_search/__mocks__/_search/all&False&&0&False&0&0&0&0&0&0&0&0&0&0&0&False&&urn&&tau*&regest&&&include&False&&advanced_resp.json
+++ b/tests/test_data/advanced_search/__mocks__/_search/all&False&&0&False&0&0&0&0&0&0&0&0&0&0&0&False&&urn&&tau*&regest&&&include&False&&advanced_resp.json
@@ -1,5 +1,5 @@
 {
-  "took": 85,
+  "took": 89,
   "timed_out": false,
   "_shards": {
     "total": 56,

--- a/tests/test_data/advanced_search/__mocks__/_search/all&False&&0&False&0&0&0&0&0&0&0&0&0&0&0&False&&urn&&tausch&regest&&&include&False&&advanced_resp.json
+++ b/tests/test_data/advanced_search/__mocks__/_search/all&False&&0&False&0&0&0&0&0&0&0&0&0&0&0&False&&urn&&tausch&regest&&&include&False&&advanced_resp.json
@@ -1,5 +1,5 @@
 {
-  "took": 17,
+  "took": 7,
   "timed_out": false,
   "_shards": {
     "total": 56,

--- a/tests/test_data/advanced_search/__mocks__/_search/all&False&&0&False&0&0&0&0&0&0&0&0&0&0&0&False&&urn&Easter&&regest&&&include&False&&advanced_resp.json
+++ b/tests/test_data/advanced_search/__mocks__/_search/all&False&&0&False&0&0&0&0&0&0&0&0&0&0&0&False&&urn&Easter&&regest&&&include&False&&advanced_resp.json
@@ -1,5 +1,5 @@
 {
-  "took": 7,
+  "took": 6,
   "timed_out": false,
   "_shards": {
     "total": 56,

--- a/tests/test_data/advanced_search/__mocks__/_search/all&False&&0&False&0&0&0&0&0&0&0&0&0&0&0&False&&urn&Easter+Saturday&&regest&&&include&False&&advanced_resp.json
+++ b/tests/test_data/advanced_search/__mocks__/_search/all&False&&0&False&0&0&0&0&0&0&0&0&0&0&0&False&&urn&Easter+Saturday&&regest&&&include&False&&advanced_resp.json
@@ -1,5 +1,5 @@
 {
-  "took": 48,
+  "took": 47,
   "timed_out": false,
   "_shards": {
     "total": 56,

--- a/tests/test_data/advanced_search/__mocks__/_search/all&False&&0&False&0&0&0&0&0&0&0&0&0&0&0&False&Basel-Augst&urn&&&regest&&&include&False&&advanced_resp.json
+++ b/tests/test_data/advanced_search/__mocks__/_search/all&False&&0&False&0&0&0&0&0&0&0&0&0&0&0&False&Basel-Augst&urn&&&regest&&&include&False&&advanced_resp.json
@@ -1,5 +1,5 @@
 {
-  "took": 4,
+  "took": 2,
   "timed_out": false,
   "_shards": {
     "total": 56,

--- a/tests/test_data/advanced_search/__mocks__/_search/all&False&&0&False&0&0&0&0&700&10&0&800&10&0&0&True&&urn&&&regest&&&include&False&&advanced_resp.json
+++ b/tests/test_data/advanced_search/__mocks__/_search/all&False&&0&False&0&0&0&0&700&10&0&800&10&0&0&True&&urn&&&regest&&&include&False&&advanced_resp.json
@@ -1,5 +1,5 @@
 {
-  "took": 21,
+  "took": 20,
   "timed_out": false,
   "_shards": {
     "total": 56,

--- a/tests/test_data/advanced_search/__mocks__/_search/all&False&&0&False&0&0&0&0&800&10&0&800&11&0&0&False&&urn&&&regest&&&include&False&&advanced_resp.json
+++ b/tests/test_data/advanced_search/__mocks__/_search/all&False&&0&False&0&0&0&0&800&10&0&800&11&0&0&False&&urn&&&regest&&&include&False&&advanced_resp.json
@@ -1,5 +1,5 @@
 {
-  "took": 25,
+  "took": 24,
   "timed_out": false,
   "_shards": {
     "total": 56,

--- a/tests/test_data/advanced_search/__mocks__/_search/all&False&&0&False&0&0&0&0&800&10&0&801&11&0&0&False&&urn&&&regest&&&include&False&&advanced_resp.json
+++ b/tests/test_data/advanced_search/__mocks__/_search/all&False&&0&False&0&0&0&0&800&10&0&801&11&0&0&False&&urn&&&regest&&&include&False&&advanced_resp.json
@@ -1,5 +1,5 @@
 {
-  "took": 27,
+  "took": 26,
   "timed_out": false,
   "_shards": {
     "total": 56,

--- a/tests/test_data/advanced_search/__mocks__/_search/all&False&&0&False&0&0&0&0&800&10&10&800&10&29&0&False&&urn&&&regest&&&include&False&&advanced_resp.json
+++ b/tests/test_data/advanced_search/__mocks__/_search/all&False&&0&False&0&0&0&0&800&10&10&800&10&29&0&False&&urn&&&regest&&&include&False&&advanced_resp.json
@@ -1,5 +1,5 @@
 {
-  "took": 31,
+  "took": 28,
   "timed_out": false,
   "_shards": {
     "total": 56,

--- a/tests/test_data/advanced_search/__mocks__/_search/all&False&&0&False&0&0&0&0&800&12&25&820&12&25&0&True&&urn&&&regest&&&include&False&&advanced_resp.json
+++ b/tests/test_data/advanced_search/__mocks__/_search/all&False&&0&False&0&0&0&0&800&12&25&820&12&25&0&True&&urn&&&regest&&&include&False&&advanced_resp.json
@@ -1,5 +1,5 @@
 {
-  "took": 5,
+  "took": 6,
   "timed_out": false,
   "_shards": {
     "total": 56,

--- a/tests/test_data/advanced_search/__mocks__/_search/all&False&&0&False&0&0&0&0&814&10&29&814&11&20&0&False&&urn&&&regest&&&include&False&&advanced_resp.json
+++ b/tests/test_data/advanced_search/__mocks__/_search/all&False&&0&False&0&0&0&0&814&10&29&814&11&20&0&False&&urn&&&regest&&&include&False&&advanced_resp.json
@@ -1,5 +1,5 @@
 {
-  "took": 66,
+  "took": 12,
   "timed_out": false,
   "_shards": {
     "total": 56,

--- a/tests/test_data/advanced_search/__mocks__/_search/all&False&&0&False&800&0&0&0&0&0&0&0&0&0&0&False&&urn&&&regest&&&include&False&&advanced_resp.json
+++ b/tests/test_data/advanced_search/__mocks__/_search/all&False&&0&False&800&0&0&0&0&0&0&0&0&0&0&False&&urn&&&regest&&&include&False&&advanced_resp.json
@@ -1,5 +1,5 @@
 {
-  "took": 30,
+  "took": 25,
   "timed_out": false,
   "_shards": {
     "total": 56,

--- a/tests/test_data/advanced_search/__mocks__/_search/all&False&&0&False&800&0&10&9&0&0&0&0&0&0&0&False&&urn&&&regest&&&include&False&&advanced_resp.json
+++ b/tests/test_data/advanced_search/__mocks__/_search/all&False&&0&False&800&0&10&9&0&0&0&0&0&0&0&False&&urn&&&regest&&&include&False&&advanced_resp.json
@@ -1,5 +1,5 @@
 {
-  "took": 29,
+  "took": 24,
   "timed_out": false,
   "_shards": {
     "total": 56,

--- a/tests/test_data/advanced_search/__mocks__/_search/all&False&&0&False&800&0&10&9&0&0&0&0&0&0&10&False&&urn&&&regest&&&include&False&&advanced_resp.json
+++ b/tests/test_data/advanced_search/__mocks__/_search/all&False&&0&False&800&0&10&9&0&0&0&0&0&0&10&False&&urn&&&regest&&&include&False&&advanced_resp.json
@@ -1,5 +1,5 @@
 {
-  "took": 26,
+  "took": 32,
   "timed_out": false,
   "_shards": {
     "total": 56,

--- a/tests/test_data/advanced_search/__mocks__/_search/all&False&adam&0&False&0&0&0&0&0&0&0&0&0&0&0&False&&urn&&&regest&&personenname&include&False&&advanced_resp.json
+++ b/tests/test_data/advanced_search/__mocks__/_search/all&False&adam&0&False&0&0&0&0&0&0&0&0&0&0&0&False&&urn&&&regest&&personenname&include&False&&advanced_resp.json
@@ -1,5 +1,5 @@
 {
-  "took": 21,
+  "took": 10,
   "timed_out": false,
   "_shards": {
     "total": 56,

--- a/tests/test_data/advanced_search/__mocks__/_search/all&False&christ?&0&False&0&0&0&0&0&0&0&0&0&0&0&False&&urn&&&regest&Narratio&&include&False&christi&advanced_resp.json
+++ b/tests/test_data/advanced_search/__mocks__/_search/all&False&christ?&0&False&0&0&0&0&0&0&0&0&0&0&0&False&&urn&&&regest&Narratio&&include&False&christi&advanced_resp.json
@@ -1,5 +1,5 @@
 {
-  "took": 51,
+  "took": 17,
   "timed_out": false,
   "_shards": {
     "total": 56,

--- a/tests/test_data/advanced_search/__mocks__/_search/all&False&habraam+usque&0&False&0&0&0&0&0&0&0&0&0&0&0&False&&urn&&&regest&&personenname&include&False&&advanced_resp.json
+++ b/tests/test_data/advanced_search/__mocks__/_search/all&False&habraam+usque&0&False&0&0&0&0&0&0&0&0&0&0&0&False&&urn&&&regest&&personenname&include&False&&advanced_resp.json
@@ -1,5 +1,5 @@
 {
-  "took": 9,
+  "took": 8,
   "timed_out": false,
   "_shards": {
     "total": 56,

--- a/tests/test_data/advanced_search/__mocks__/_search/all&False&illam&0&False&0&0&0&0&0&0&0&0&0&0&0&y&&urn&&tau&autocomplete_regest&&&include&False&&advanced_resp.json
+++ b/tests/test_data/advanced_search/__mocks__/_search/all&False&illam&0&False&0&0&0&0&0&0&0&0&0&0&0&y&&urn&&tau&autocomplete_regest&&&include&False&&advanced_resp.json
@@ -1,5 +1,5 @@
 {
-  "took": 18,
+  "took": 16,
   "timed_out": false,
   "_shards": {
     "total": 56,

--- a/tests/test_data/advanced_search/__mocks__/_search/all&False&novalium&0&False&0&0&0&0&0&0&0&0&0&0&0&False&&urn&&&regest&&&include&False&&advanced_resp.json
+++ b/tests/test_data/advanced_search/__mocks__/_search/all&False&novalium&0&False&0&0&0&0&0&0&0&0&0&0&0&False&&urn&&&regest&&&include&False&&advanced_resp.json
@@ -1,5 +1,5 @@
 {
-  "took": 30,
+  "took": 16,
   "timed_out": false,
   "_shards": {
     "total": 56,

--- a/tests/test_data/advanced_search/__mocks__/_search/all&False&regn?&0&False&0&0&0&0&0&0&0&0&0&0&0&False&&urn&&&regest&&&include&False&regni&advanced_resp.json
+++ b/tests/test_data/advanced_search/__mocks__/_search/all&False&regn?&0&False&0&0&0&0&0&0&0&0&0&0&0&False&&urn&&&regest&&&include&False&regni&advanced_resp.json
@@ -1,5 +1,5 @@
 {
-  "took": 36,
+  "took": 28,
   "timed_out": false,
   "_shards": {
     "total": 56,

--- a/tests/test_data/advanced_search/__mocks__/_search/all&False&regnum&0&False&0&0&0&0&0&0&0&0&0&0&0&False&&urn&&&regest&&&include&False&&advanced_resp.json
+++ b/tests/test_data/advanced_search/__mocks__/_search/all&False&regnum&0&False&0&0&0&0&0&0&0&0&0&0&0&False&&urn&&&regest&&&include&False&&advanced_resp.json
@@ -1,5 +1,5 @@
 {
-  "took": 48,
+  "took": 24,
   "timed_out": false,
   "_shards": {
     "total": 56,

--- a/tests/test_data/advanced_search/__mocks__/_search/all&False&regnum&0&False&0&0&0&0&0&0&0&0&0&0&0&False&&urn&&&regest&&personenname&include&False&&advanced_resp.json
+++ b/tests/test_data/advanced_search/__mocks__/_search/all&False&regnum&0&False&0&0&0&0&0&0&0&0&0&0&0&False&&urn&&&regest&&personenname&include&False&&advanced_resp.json
@@ -1,5 +1,5 @@
 {
-  "took": 38,
+  "took": 24,
   "timed_out": false,
   "_shards": {
     "total": 56,

--- a/tests/test_data/advanced_search/__mocks__/_search/all&False&regnum&0&False&0&0&0&0&0&0&0&0&0&0&0&False&&urn&&schenk*&regest&&&include&False&&advanced_resp.json
+++ b/tests/test_data/advanced_search/__mocks__/_search/all&False&regnum&0&False&0&0&0&0&0&0&0&0&0&0&0&False&&urn&&schenk*&regest&&&include&False&&advanced_resp.json
@@ -1,5 +1,5 @@
 {
-  "took": 30,
+  "took": 17,
   "timed_out": false,
   "_shards": {
     "total": 56,

--- a/tests/test_data/advanced_search/__mocks__/_search/all&False&regnum+dom*&0&False&0&0&0&0&0&0&0&0&0&0&0&False&&urn&&&regest&&&include&False&&advanced_resp.json
+++ b/tests/test_data/advanced_search/__mocks__/_search/all&False&regnum+dom*&0&False&0&0&0&0&0&0&0&0&0&0&0&False&&urn&&&regest&&&include&False&&advanced_resp.json
@@ -1,5 +1,5 @@
 {
-  "took": 74,
+  "took": 17,
   "timed_out": false,
   "_shards": {
     "total": 56,

--- a/tests/test_data/advanced_search/__mocks__/_search/all&False&regnum+domni&0&False&0&0&0&0&0&0&0&0&0&0&0&False&&urn&&&regest&&personenname&include&False&&advanced_resp.json
+++ b/tests/test_data/advanced_search/__mocks__/_search/all&False&regnum+domni&0&False&0&0&0&0&0&0&0&0&0&0&0&False&&urn&&&regest&&personenname&include&False&&advanced_resp.json
@@ -1,5 +1,5 @@
 {
-  "took": 16,
+  "took": 13,
   "timed_out": false,
   "_shards": {
     "total": 56,

--- a/tests/test_data/advanced_search/__mocks__/_search/all&False&wolfhart+cvm&0&False&0&0&0&0&0&0&0&0&0&0&0&False&&urn&&&regest&&&include&False&&advanced_resp.json
+++ b/tests/test_data/advanced_search/__mocks__/_search/all&False&wolfhart+cvm&0&False&0&0&0&0&0&0&0&0&0&0&0&False&&urn&&&regest&&&include&False&&advanced_resp.json
@@ -1,5 +1,5 @@
 {
-  "took": 18,
+  "took": 16,
   "timed_out": false,
   "_shards": {
     "total": 56,

--- a/tests/test_data/advanced_search/__mocks__/_search/all&True&facio+gero&0&False&0&0&0&0&0&0&0&0&0&0&0&False&&urn&&&regest&&&include&False&&advanced_req.json
+++ b/tests/test_data/advanced_search/__mocks__/_search/all&True&facio+gero&0&False&0&0&0&0&0&0&0&0&0&0&0&False&&urn&&&regest&&&include&False&&advanced_req.json
@@ -57,38 +57,6 @@
                         "match": {
                           "fuzzy": {
                             "lemmas": {
-                              "value": "gesta",
-                              "fuzziness": "0"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  ],
-                  "slop": "0",
-                  "in_order": false
-                }
-              },
-              {
-                "span_near": {
-                  "clauses": [
-                    {
-                      "span_multi": {
-                        "match": {
-                          "fuzzy": {
-                            "lemmas": {
-                              "value": "facio",
-                              "fuzziness": "0"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    {
-                      "span_multi": {
-                        "match": {
-                          "fuzzy": {
-                            "lemmas": {
                               "value": "gestus",
                               "fuzziness": "0"
                             }
@@ -121,7 +89,7 @@
                         "match": {
                           "fuzzy": {
                             "lemmas": {
-                              "value": "gerereve",
+                              "value": "gesta",
                               "fuzziness": "0"
                             }
                           }
@@ -173,103 +141,7 @@
                         "match": {
                           "fuzzy": {
                             "lemmas": {
-                              "value": "factus",
-                              "fuzziness": "0"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    {
-                      "span_multi": {
-                        "match": {
-                          "fuzzy": {
-                            "lemmas": {
-                              "value": "gero",
-                              "fuzziness": "0"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  ],
-                  "slop": "0",
-                  "in_order": false
-                }
-              },
-              {
-                "span_near": {
-                  "clauses": [
-                    {
-                      "span_multi": {
-                        "match": {
-                          "fuzzy": {
-                            "lemmas": {
-                              "value": "factus",
-                              "fuzziness": "0"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    {
-                      "span_multi": {
-                        "match": {
-                          "fuzzy": {
-                            "lemmas": {
-                              "value": "gesta",
-                              "fuzziness": "0"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  ],
-                  "slop": "0",
-                  "in_order": false
-                }
-              },
-              {
-                "span_near": {
-                  "clauses": [
-                    {
-                      "span_multi": {
-                        "match": {
-                          "fuzzy": {
-                            "lemmas": {
-                              "value": "factus",
-                              "fuzziness": "0"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    {
-                      "span_multi": {
-                        "match": {
-                          "fuzzy": {
-                            "lemmas": {
-                              "value": "gestus",
-                              "fuzziness": "0"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  ],
-                  "slop": "0",
-                  "in_order": false
-                }
-              },
-              {
-                "span_near": {
-                  "clauses": [
-                    {
-                      "span_multi": {
-                        "match": {
-                          "fuzzy": {
-                            "lemmas": {
-                              "value": "factus",
+                              "value": "facio",
                               "fuzziness": "0"
                             }
                           }
@@ -282,38 +154,6 @@
                           "fuzzy": {
                             "lemmas": {
                               "value": "gerereve",
-                              "fuzziness": "0"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  ],
-                  "slop": "0",
-                  "in_order": false
-                }
-              },
-              {
-                "span_near": {
-                  "clauses": [
-                    {
-                      "span_multi": {
-                        "match": {
-                          "fuzzy": {
-                            "lemmas": {
-                              "value": "factus",
-                              "fuzziness": "0"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    {
-                      "span_multi": {
-                        "match": {
-                          "fuzzy": {
-                            "lemmas": {
-                              "value": "gerere",
                               "fuzziness": "0"
                             }
                           }
@@ -377,6 +217,38 @@
                         "match": {
                           "fuzzy": {
                             "lemmas": {
+                              "value": "gestus",
+                              "fuzziness": "0"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  ],
+                  "slop": "0",
+                  "in_order": false
+                }
+              },
+              {
+                "span_near": {
+                  "clauses": [
+                    {
+                      "span_multi": {
+                        "match": {
+                          "fuzzy": {
+                            "lemmas": {
+                              "value": "facere",
+                              "fuzziness": "0"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "span_multi": {
+                        "match": {
+                          "fuzzy": {
+                            "lemmas": {
                               "value": "gesta",
                               "fuzziness": "0"
                             }
@@ -409,7 +281,7 @@
                         "match": {
                           "fuzzy": {
                             "lemmas": {
-                              "value": "gestus",
+                              "value": "gerere",
                               "fuzziness": "0"
                             }
                           }
@@ -461,7 +333,103 @@
                         "match": {
                           "fuzzy": {
                             "lemmas": {
-                              "value": "facere",
+                              "value": "factus",
+                              "fuzziness": "0"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "span_multi": {
+                        "match": {
+                          "fuzzy": {
+                            "lemmas": {
+                              "value": "gero",
+                              "fuzziness": "0"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  ],
+                  "slop": "0",
+                  "in_order": false
+                }
+              },
+              {
+                "span_near": {
+                  "clauses": [
+                    {
+                      "span_multi": {
+                        "match": {
+                          "fuzzy": {
+                            "lemmas": {
+                              "value": "factus",
+                              "fuzziness": "0"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "span_multi": {
+                        "match": {
+                          "fuzzy": {
+                            "lemmas": {
+                              "value": "gestus",
+                              "fuzziness": "0"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  ],
+                  "slop": "0",
+                  "in_order": false
+                }
+              },
+              {
+                "span_near": {
+                  "clauses": [
+                    {
+                      "span_multi": {
+                        "match": {
+                          "fuzzy": {
+                            "lemmas": {
+                              "value": "factus",
+                              "fuzziness": "0"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "span_multi": {
+                        "match": {
+                          "fuzzy": {
+                            "lemmas": {
+                              "value": "gesta",
+                              "fuzziness": "0"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  ],
+                  "slop": "0",
+                  "in_order": false
+                }
+              },
+              {
+                "span_near": {
+                  "clauses": [
+                    {
+                      "span_multi": {
+                        "match": {
+                          "fuzzy": {
+                            "lemmas": {
+                              "value": "factus",
                               "fuzziness": "0"
                             }
                           }
@@ -474,6 +442,38 @@
                           "fuzzy": {
                             "lemmas": {
                               "value": "gerere",
+                              "fuzziness": "0"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  ],
+                  "slop": "0",
+                  "in_order": false
+                }
+              },
+              {
+                "span_near": {
+                  "clauses": [
+                    {
+                      "span_multi": {
+                        "match": {
+                          "fuzzy": {
+                            "lemmas": {
+                              "value": "factus",
+                              "fuzziness": "0"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "span_multi": {
+                        "match": {
+                          "fuzzy": {
+                            "lemmas": {
+                              "value": "gerereve",
                               "fuzziness": "0"
                             }
                           }

--- a/tests/test_data/advanced_search/__mocks__/_search/all&True&facio+gero&0&False&0&0&0&0&0&0&0&0&0&0&0&False&&urn&&&regest&&&include&False&&advanced_resp.json
+++ b/tests/test_data/advanced_search/__mocks__/_search/all&True&facio+gero&0&False&0&0&0&0&0&0&0&0&0&0&0&False&&urn&&&regest&&&include&False&&advanced_resp.json
@@ -1,5 +1,5 @@
 {
-  "took": 10,
+  "took": 7,
   "timed_out": false,
   "_shards": {
     "total": 56,

--- a/tests/test_data/advanced_search/__mocks__/_search/all&True&gero&0&False&0&0&0&0&0&0&0&0&0&0&0&False&&urn&&&regest&&&include&False&&advanced_req.json
+++ b/tests/test_data/advanced_search/__mocks__/_search/all&True&gero&0&False&0&0&0&0&0&0&0&0&0&0&0&False&&urn&&&regest&&&include&False&&advanced_req.json
@@ -33,26 +33,6 @@
                         "match": {
                           "fuzzy": {
                             "lemmas": {
-                              "value": "gesta",
-                              "fuzziness": "0"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  ],
-                  "slop": "0",
-                  "in_order": false
-                }
-              },
-              {
-                "span_near": {
-                  "clauses": [
-                    {
-                      "span_multi": {
-                        "match": {
-                          "fuzzy": {
-                            "lemmas": {
                               "value": "gestus",
                               "fuzziness": "0"
                             }
@@ -73,7 +53,7 @@
                         "match": {
                           "fuzzy": {
                             "lemmas": {
-                              "value": "gerereve",
+                              "value": "gesta",
                               "fuzziness": "0"
                             }
                           }
@@ -94,6 +74,26 @@
                           "fuzzy": {
                             "lemmas": {
                               "value": "gerere",
+                              "fuzziness": "0"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  ],
+                  "slop": "0",
+                  "in_order": false
+                }
+              },
+              {
+                "span_near": {
+                  "clauses": [
+                    {
+                      "span_multi": {
+                        "match": {
+                          "fuzzy": {
+                            "lemmas": {
+                              "value": "gerereve",
                               "fuzziness": "0"
                             }
                           }

--- a/tests/test_data/advanced_search/__mocks__/_search/all&True&gero&0&False&0&0&0&0&0&0&0&0&0&0&0&False&&urn&&&regest&&&include&False&&advanced_resp.json
+++ b/tests/test_data/advanced_search/__mocks__/_search/all&True&gero&0&False&0&0&0&0&0&0&0&0&0&0&0&False&&urn&&&regest&&&include&False&&advanced_resp.json
@@ -1,5 +1,5 @@
 {
-  "took": 13,
+  "took": 11,
   "timed_out": false,
   "_shards": {
     "total": 56,

--- a/tests/test_data/advanced_search/__mocks__/_search/all&True&regnum&0&False&0&0&0&0&0&0&0&0&0&0&0&False&&urn&&&regest&&&include&False&&advanced_resp.json
+++ b/tests/test_data/advanced_search/__mocks__/_search/all&True&regnum&0&False&0&0&0&0&0&0&0&0&0&0&0&False&&urn&&&regest&&&include&False&&advanced_resp.json
@@ -1,5 +1,5 @@
 {
-  "took": 12,
+  "took": 10,
   "timed_out": false,
   "_shards": {
     "total": 56,

--- a/tests/test_data/advanced_search/__mocks__/_search/all&True&vir+venerabilis&0&False&0&0&0&0&0&0&0&0&0&0&0&False&&urn&&&regest&&&include&False&&advanced_resp.json
+++ b/tests/test_data/advanced_search/__mocks__/_search/all&True&vir+venerabilis&0&False&0&0&0&0&0&0&0&0&0&0&0&False&&urn&&&regest&&&include&False&&advanced_resp.json
@@ -1,5 +1,5 @@
 {
-  "took": 7,
+  "took": 6,
   "timed_out": false,
   "_shards": {
     "total": 56,

--- a/tests/test_data/advanced_search/__mocks__/_search/andecavensis+mondsee&False&&0&False&0&0&0&0&814&10&29&814&11&20&0&False&&urn&&&regest&&&include&False&&advanced_resp.json
+++ b/tests/test_data/advanced_search/__mocks__/_search/andecavensis+mondsee&False&&0&False&0&0&0&0&814&10&29&814&11&20&0&False&&urn&&&regest&&&include&False&&advanced_resp.json
@@ -1,5 +1,5 @@
 {
-  "took": 1,
+  "took": 2,
   "timed_out": false,
   "_shards": {
     "total": 2,

--- a/tests/test_data/advanced_search/__mocks__/_search/buenden&False&&0&False&0&0&0&0&0&0&0&0&0&0&0&False&&urn&&schenk*&regest&&&include&False&&advanced_resp.json
+++ b/tests/test_data/advanced_search/__mocks__/_search/buenden&False&&0&False&0&0&0&0&0&0&0&0&0&0&0&False&&urn&&schenk*&regest&&&include&False&&advanced_resp.json
@@ -1,5 +1,5 @@
 {
-  "took": 4,
+  "took": 2,
   "timed_out": false,
   "_shards": {
     "total": 1,

--- a/tests/test_data/advanced_search/__mocks__/_search/buenden&False&&0&False&0&0&0&0&0&0&0&0&0&0&0&y&&urn&&sche&autocomplete_regest&&&include&False&&advanced_resp.json
+++ b/tests/test_data/advanced_search/__mocks__/_search/buenden&False&&0&False&0&0&0&0&0&0&0&0&0&0&0&y&&urn&&sche&autocomplete_regest&&&include&False&&advanced_resp.json
@@ -1,5 +1,5 @@
 {
-  "took": 2,
+  "took": 1,
   "timed_out": false,
   "_shards": {
     "total": 1,

--- a/tests/test_data/advanced_search/__mocks__/_search/buenden&False&a&0&False&0&0&0&0&0&0&0&0&0&0&0&False&&urn&&&regest&&&include&False&&advanced_resp.json
+++ b/tests/test_data/advanced_search/__mocks__/_search/buenden&False&a&0&False&0&0&0&0&0&0&0&0&0&0&0&False&&urn&&&regest&&&include&False&&advanced_resp.json
@@ -1,5 +1,5 @@
 {
-  "took": 15,
+  "took": 7,
   "timed_out": false,
   "_shards": {
     "total": 1,

--- a/tests/test_data/advanced_search/__mocks__/_search/buenden&False&pettone&AUTO&False&0&0&0&0&0&0&0&0&0&0&0&False&&urn&&&regest&&&include&False&&advanced_resp.json
+++ b/tests/test_data/advanced_search/__mocks__/_search/buenden&False&pettone&AUTO&False&0&0&0&0&0&0&0&0&0&0&0&False&&urn&&&regest&&&include&False&&advanced_resp.json
@@ -1,5 +1,5 @@
 {
-  "took": 8,
+  "took": 9,
   "timed_out": false,
   "_shards": {
     "total": 1,

--- a/tests/test_data/advanced_search/__mocks__/_search/buenden&False&regnante+pettone&AUTO&False&0&0&0&0&0&0&0&0&0&0&0&False&&urn&&&regest&&&include&False&&advanced_resp.json
+++ b/tests/test_data/advanced_search/__mocks__/_search/buenden&False&regnante+pettone&AUTO&False&0&0&0&0&0&0&0&0&0&0&0&False&&urn&&&regest&&&include&False&&advanced_resp.json
@@ -1,5 +1,5 @@
 {
-  "took": 6,
+  "took": 5,
   "timed_out": false,
   "_shards": {
     "total": 1,

--- a/tests/test_data/advanced_search/__mocks__/_search/buenden&False&regnum&0&False&0&0&0&0&0&0&0&0&0&0&0&False&&urn&&&regest&&&include&False&&advanced_resp.json
+++ b/tests/test_data/advanced_search/__mocks__/_search/buenden&False&regnum&0&False&0&0&0&0&0&0&0&0&0&0&0&False&&urn&&&regest&&&include&False&&advanced_resp.json
@@ -1,5 +1,5 @@
 {
-  "took": 3,
+  "took": 2,
   "timed_out": false,
   "_shards": {
     "total": 1,

--- a/tests/test_data/advanced_search/__mocks__/_search/buenden&False&regnum+domni&0&False&0&0&0&0&0&0&0&0&0&0&0&False&&urn&&&regest&&&include&False&&advanced_resp.json
+++ b/tests/test_data/advanced_search/__mocks__/_search/buenden&False&regnum+domni&0&False&0&0&0&0&0&0&0&0&0&0&0&False&&urn&&&regest&&&include&False&&advanced_resp.json
@@ -1,5 +1,5 @@
 {
-  "took": 3,
+  "took": 2,
   "timed_out": false,
   "_shards": {
     "total": 1,

--- a/tests/test_data/advanced_search/__mocks__/_search/buenden&False&scripsi+et+suscr*&AUTO&False&0&0&0&0&0&0&0&0&0&0&0&False&&urn&&&regest&&&include&False&&advanced_resp.json
+++ b/tests/test_data/advanced_search/__mocks__/_search/buenden&False&scripsi+et+suscr*&AUTO&False&0&0&0&0&0&0&0&0&0&0&0&False&&urn&&&regest&&&include&False&&advanced_resp.json
@@ -1,5 +1,5 @@
 {
-  "took": 3,
+  "took": 4,
   "timed_out": false,
   "_shards": {
     "total": 1,

--- a/tests/test_data/advanced_search/__mocks__/_search/buenden&False&scripsi+et+suscripsi&0&False&0&0&0&0&0&0&0&0&0&0&0&False&&urn&&&regest&&&include&False&&advanced_resp.json
+++ b/tests/test_data/advanced_search/__mocks__/_search/buenden&False&scripsi+et+suscripsi&0&False&0&0&0&0&0&0&0&0&0&0&0&False&&urn&&&regest&&&include&False&&advanced_resp.json
@@ -1,5 +1,5 @@
 {
-  "took": 3,
+  "took": 1,
   "timed_out": false,
   "_shards": {
     "total": 1,

--- a/tests/test_data/advanced_search/__mocks__/_search/buenden&False&signum+uuiliarentis+testes+signum+crespionis+testes&0&False&0&0&0&0&0&0&0&0&0&0&0&False&&urn&&&regest&&&include&False&&advanced_resp.json
+++ b/tests/test_data/advanced_search/__mocks__/_search/buenden&False&signum+uuiliarentis+testes+signum+crespionis+testes&0&False&0&0&0&0&0&0&0&0&0&0&0&False&&urn&&&regest&&&include&False&&advanced_resp.json
@@ -1,5 +1,5 @@
 {
-  "took": 5,
+  "took": 4,
   "timed_out": false,
   "_shards": {
     "total": 1,

--- a/tests/test_data/advanced_search/__mocks__/_search/buenden&autocomplete&scrips&0&False&0&0&0&0&0&0&0&0&0&0&0&y&&urn&&&regest&&&include&False&&advanced_resp.json
+++ b/tests/test_data/advanced_search/__mocks__/_search/buenden&autocomplete&scrips&0&False&0&0&0&0&0&0&0&0&0&0&0&y&&urn&&&regest&&&include&False&&advanced_resp.json
@@ -1,5 +1,5 @@
 {
-  "took": 15,
+  "took": 8,
   "timed_out": false,
   "_shards": {
     "total": 1,

--- a/tests/test_data/advanced_search/__mocks__/_search/elexicon&False&diakon?+m?rtyr*&0&False&0&0&0&0&0&0&0&0&0&0&0&False&&urn&&&regest&&&include&False&&advanced_resp.json
+++ b/tests/test_data/advanced_search/__mocks__/_search/elexicon&False&diakon?+m?rtyr*&0&False&0&0&0&0&0&0&0&0&0&0&0&False&&urn&&&regest&&&include&False&&advanced_resp.json
@@ -20,16 +20,16 @@
         "_id": "urn:cts:formulae:elexicon.martyrarius.deu001",
         "_score": null,
         "_source": {
-          "text": "some real text",
-          "lemmas": "lemma text",
-          "regest": "regest text",
+          "text": "Martyrarius Hüter eines Märtyrergrabes, Reliquienhüter. Seit der ersten Hälfte des 6. Jahrhunderts belegt, scheint es sich beim martyrarius um einen Geistlichen gehandelt zu haben, dem die Fürsorge für ein Märtyrergrab oblag. Könnte es sich dabei zunächst noch um ein spezielles Amt gehandelt haben, so scheint martyrarius bald eine besondere Funktion zu bezeichnen, die verschiedene Amtsträger wie etwa Diakone oder Äbte innehaben konnten. HL",
+          "lemmas": null,
+          "regest": null,
           "title": "Martyrarius",
           "urn": "urn:cts:formulae:elexicon.martyrarius.deu001",
           "date_string": " ",
           "comp_ort": " ",
-          "autocomplete": "autocomplete text",
-          "autocomplete_lemmas": "autocomplete lemma text",
-          "autocomplete_regest": "autocomplete regest text",
+          "autocomplete": "Martyrarius Hüter eines Märtyrergrabes, Reliquienhüter. Seit der ersten Hälfte des 6. Jahrhunderts belegt, scheint es sich beim martyrarius um einen Geistlichen gehandelt zu haben, dem die Fürsorge für ein Märtyrergrab oblag. Könnte es sich dabei zunächst noch um ein spezielles Amt gehandelt haben, so scheint martyrarius bald eine besondere Funktion zu bezeichnen, die verschiedene Amtsträger wie etwa Diakone oder Äbte innehaben konnten. HL",
+          "autocomplete_lemmas": null,
+          "autocomplete_regest": null,
           "orig_comp_ort": " ",
           "collection": "elexicon",
           "forgery": false,
@@ -37,7 +37,11 @@
         },
         "highlight": {
           "text": [
-            "text"
+            "</small><strong>Martyrarius</strong><small> Hüter eines </small><strong>Märtyrergrabes</strong><small>, Reliquienhüter. Seit der ersten Hälfte des 6.",
+            "Jahrhunderts belegt, scheint es sich beim </small><strong>martyrarius</strong><small> um einen Geistlichen gehandelt zu haben, dem die",
+            "Fürsorge für ein </small><strong>Märtyrergrab</strong><small> oblag.",
+            "Könnte es sich dabei zunächst noch um ein spezielles Amt gehandelt haben, so scheint </small><strong>martyrarius</strong><small> bald",
+            "eine besondere Funktion zu bezeichnen, die verschiedene Amtsträger wie etwa </small><strong>Diakone</strong><small> oder Äbte innehaben"
           ]
         },
         "sort": [

--- a/tests/test_data/advanced_search/__mocks__/_search/elexicon&False&diakone&0&False&0&0&0&0&0&0&0&0&0&0&0&False&&urn&&&regest&&&include&False&&advanced_resp.json
+++ b/tests/test_data/advanced_search/__mocks__/_search/elexicon&False&diakone&0&False&0&0&0&0&0&0&0&0&0&0&0&False&&urn&&&regest&&&include&False&&advanced_resp.json
@@ -1,5 +1,5 @@
 {
-  "took": 7,
+  "took": 1,
   "timed_out": false,
   "_shards": {
     "total": 1,
@@ -20,16 +20,16 @@
         "_id": "urn:cts:formulae:elexicon.diaconus.deu001",
         "_score": null,
         "_source": {
-          "text": "some real text",
-          "lemmas": "lemma text",
-          "regest": "regest text",
+          "text": "Diaconus Diakon, kirchliches Amt des dritten Weihegrades. Der Begriff Diakon scheint aus jüdischer und hellenistisch-römischer Tradition zu stammen, ohne dass sich näheres über seine Herkunft feststellen ließe. Diakone sind bereits bei Paulus bezeugt (Phil. 1, 1) und erscheinen im Neuen Testament als Diener und Gehilfen der Apostel. In der Frühzeit der Kirche wurden Diakone gemeinsam mit den Bischöfen von der Gemeinde gewählt, waren diesen als Helfer zugeordnet und zunächst mit dem Vollzug der Liturgie betraut. Aus der Nähe zum Bischof resultierte bald die Übernahme administrativer Tätigkeiten bis hin zur Stellvertretung desselben. Mit dem Konzil von Nicäa 325 wurden die Diakone innerhalb des Klerus hinter den Presbytern eingestuft. Sie erhielten fortan zwar eine Weihe dritten Grades, gehörten aber nicht dem Priesterstand an. Zugleich wurden ihre Kompetenzen eingeschränkt und ihre Aufgaben hinsichtlich der Liturgie präzisiert. In der Merowingerzeit traten Diakone auch in der Funktion des aedituus Pförtner, Küstner, Sakristan oder Messner) einer basilica auf. Neben Diakonen sind in der frühen Kirche auch Diakoninnen bezeugt. Im 4. und 5. Jahrhundert im Westen auf Konzilien verurteilt, finden sich in der Folge nur sehr wenige Nennungen von Diakoninnen, bei denen es sich jedoch auch um einen Ehrentitel oder die Ehefrau des Diakons handeln konnte. Das Amt des archidiaconus entstand wohl im 5. Jahrhundert. Seit dem 6. Jahrhundert gehörten diese immer zu einer Bischofskirche und waren für die Ausbildung und Aufrechterhaltung der Disziplin der Kleriker zuständig. Bis Mitte des 9. Jahrhunderts stiegen die archidiaconi zu den wichtigsten Mitarbeitern der Bischöfe auf. Im hohen und späten Mittelalter war die Machtfülle einiger Diakone offenbar so angewachsen, dass sie die Position ihrer Bischöfe bedrohen konnten. HL",
+          "lemmas": null,
+          "regest": null,
           "title": "Diaconus",
           "urn": "urn:cts:formulae:elexicon.diaconus.deu001",
           "date_string": " ",
           "comp_ort": " ",
-          "autocomplete": "autocomplete text",
-          "autocomplete_lemmas": "autocomplete lemma text",
-          "autocomplete_regest": "autocomplete regest text",
+          "autocomplete": "Diaconus Diakon, kirchliches Amt des dritten Weihegrades. Der Begriff Diakon scheint aus jüdischer und hellenistisch-römischer Tradition zu stammen, ohne dass sich näheres über seine Herkunft feststellen ließe. Diakone sind bereits bei Paulus bezeugt (Phil. 1, 1) und erscheinen im Neuen Testament als Diener und Gehilfen der Apostel. In der Frühzeit der Kirche wurden Diakone gemeinsam mit den Bischöfen von der Gemeinde gewählt, waren diesen als Helfer zugeordnet und zunächst mit dem Vollzug der Liturgie betraut. Aus der Nähe zum Bischof resultierte bald die Übernahme administrativer Tätigkeiten bis hin zur Stellvertretung desselben. Mit dem Konzil von Nicäa 325 wurden die Diakone innerhalb des Klerus hinter den Presbytern eingestuft. Sie erhielten fortan zwar eine Weihe dritten Grades, gehörten aber nicht dem Priesterstand an. Zugleich wurden ihre Kompetenzen eingeschränkt und ihre Aufgaben hinsichtlich der Liturgie präzisiert. In der Merowingerzeit traten Diakone auch in der Funktion des aedituus Pförtner, Küstner, Sakristan oder Messner) einer basilica auf. Neben Diakonen sind in der frühen Kirche auch Diakoninnen bezeugt. Im 4. und 5. Jahrhundert im Westen auf Konzilien verurteilt, finden sich in der Folge nur sehr wenige Nennungen von Diakoninnen, bei denen es sich jedoch auch um einen Ehrentitel oder die Ehefrau des Diakons handeln konnte. Das Amt des archidiaconus entstand wohl im 5. Jahrhundert. Seit dem 6. Jahrhundert gehörten diese immer zu einer Bischofskirche und waren für die Ausbildung und Aufrechterhaltung der Disziplin der Kleriker zuständig. Bis Mitte des 9. Jahrhunderts stiegen die archidiaconi zu den wichtigsten Mitarbeitern der Bischöfe auf. Im hohen und späten Mittelalter war die Machtfülle einiger Diakone offenbar so angewachsen, dass sie die Position ihrer Bischöfe bedrohen konnten. HL",
+          "autocomplete_lemmas": null,
+          "autocomplete_regest": null,
           "orig_comp_ort": " ",
           "collection": "elexicon",
           "forgery": false,
@@ -37,7 +37,11 @@
         },
         "highlight": {
           "text": [
-            "text"
+            "</small><strong>Diakone</strong><small> sind bereits bei Paulus bezeugt (Phil. 1, 1) und erscheinen im Neuen Testament als Diener und",
+            "In der Frühzeit der Kirche wurden </small><strong>Diakone</strong><small> gemeinsam mit den Bischöfen von der Gemeinde gewählt, waren",
+            "Mit dem Konzil von Nicäa 325 wurden die </small><strong>Diakone</strong><small> innerhalb des Klerus hinter den Presbytern eingestuft",
+            "In der Merowingerzeit traten </small><strong>Diakone</strong><small> auch in der Funktion des aedituus Pförtner, Küstner, Sakristan oder",
+            "Im hohen und späten Mittelalter war die Machtfülle einiger </small><strong>Diakone</strong><small> offenbar so angewachsen, dass sie"
           ]
         },
         "sort": [
@@ -51,16 +55,16 @@
         "_id": "urn:cts:formulae:elexicon.episcopus.deu001",
         "_score": null,
         "_source": {
-          "text": "some real text",
-          "lemmas": "lemma text",
-          "regest": "regest text",
+          "text": "Episcopus Bischof; aus dem Griechischen ins Lateinische übernommen, wörtlich „Aufseher“. Synonym für episcopus werden auch sacerdos antistes praesul pontifex papa und presbyter gebraucht. Im christlichen Umfeld agierten episcopi zunächst wohl, wie Presbyter und Diakone, als Ratgeber und Vorsteher der Gemeinde. Endgültig zum Leiter einer Gemeinde stieg der episcopus wohl mit der Ausbildung einer bischöflichen Kirchenordnung im 2. -3. Jahrhundert auf. Zunehmend durch kanonische Satzungen geregelt, wurde das Episkopat nunmehr zum höchsten kirchlichen Weihegrad und zum dauerhaften Amt mit fest abgegrenztem Sprengel. Die Bischofswahl sollte in der Spätantike durch die anderen Bischöfe der Provinz unter Berücksichtigung des Willens der Gemeinde erfolgen. Im Frühmittelalter sah das kanonische Recht die Wahl durch populus und Klerus der Gemeinde, unter Mitsprache der Mitbischöfe und des Metropoliten, vor, wurde in der Praxis jedoch häufig durch die Einflussnahme des Herrschers oder des lokalen Adels entschieden. Der Bischof war die zentrale Autorität der Gemeinde; ihm oblagen die Durchführung der zentralen Bestandteile der Liturgie sowie die Aufsicht über die anderen Kleriker. Seit Konstantin dem Großen wurde zudem die bischöfliche Gerichtsbarkeit in bestimmten Fällen anerkannt, die schließlich auch auf die Zivilgerichtsbarkeit ausgedehnt wurde. In fränkischer Zeit übernahmen zahlreiche Bischöfe die Aufgaben der städtischen curia und konnten schließlich als Stellvertreter des Königs fungieren. Nach einer Beschneidung der weltlichen Macht der Bischöfe durch die frühen Karolinger entwickelten sich seit dem 9. Jahrhundert zahlreiche Bischöfe durch die Übertragung von Immunität, Königsschutz und Herrschaftsrechten zu Stadtherren und zentralen Trägern der Königsherrschaft. HL",
+          "lemmas": null,
+          "regest": null,
           "title": "Episcopus",
           "urn": "urn:cts:formulae:elexicon.episcopus.deu001",
           "date_string": " ",
           "comp_ort": " ",
-          "autocomplete": "autocomplete text",
-          "autocomplete_lemmas": "autocomplete lemma text",
-          "autocomplete_regest": "autocomplete regest text",
+          "autocomplete": "Episcopus Bischof; aus dem Griechischen ins Lateinische übernommen, wörtlich „Aufseher“. Synonym für episcopus werden auch sacerdos antistes praesul pontifex papa und presbyter gebraucht. Im christlichen Umfeld agierten episcopi zunächst wohl, wie Presbyter und Diakone, als Ratgeber und Vorsteher der Gemeinde. Endgültig zum Leiter einer Gemeinde stieg der episcopus wohl mit der Ausbildung einer bischöflichen Kirchenordnung im 2. -3. Jahrhundert auf. Zunehmend durch kanonische Satzungen geregelt, wurde das Episkopat nunmehr zum höchsten kirchlichen Weihegrad und zum dauerhaften Amt mit fest abgegrenztem Sprengel. Die Bischofswahl sollte in der Spätantike durch die anderen Bischöfe der Provinz unter Berücksichtigung des Willens der Gemeinde erfolgen. Im Frühmittelalter sah das kanonische Recht die Wahl durch populus und Klerus der Gemeinde, unter Mitsprache der Mitbischöfe und des Metropoliten, vor, wurde in der Praxis jedoch häufig durch die Einflussnahme des Herrschers oder des lokalen Adels entschieden. Der Bischof war die zentrale Autorität der Gemeinde; ihm oblagen die Durchführung der zentralen Bestandteile der Liturgie sowie die Aufsicht über die anderen Kleriker. Seit Konstantin dem Großen wurde zudem die bischöfliche Gerichtsbarkeit in bestimmten Fällen anerkannt, die schließlich auch auf die Zivilgerichtsbarkeit ausgedehnt wurde. In fränkischer Zeit übernahmen zahlreiche Bischöfe die Aufgaben der städtischen curia und konnten schließlich als Stellvertreter des Königs fungieren. Nach einer Beschneidung der weltlichen Macht der Bischöfe durch die frühen Karolinger entwickelten sich seit dem 9. Jahrhundert zahlreiche Bischöfe durch die Übertragung von Immunität, Königsschutz und Herrschaftsrechten zu Stadtherren und zentralen Trägern der Königsherrschaft. HL",
+          "autocomplete_lemmas": null,
+          "autocomplete_regest": null,
           "orig_comp_ort": " ",
           "collection": "elexicon",
           "forgery": false,
@@ -68,7 +72,7 @@
         },
         "highlight": {
           "text": [
-            "text"
+            "Im christlichen Umfeld agierten episcopi zunächst wohl, wie Presbyter und </small><strong>Diakone</strong><small>, als Ratgeber und Vorsteher"
           ]
         },
         "sort": [
@@ -82,16 +86,16 @@
         "_id": "urn:cts:formulae:elexicon.martyrarius.deu001",
         "_score": null,
         "_source": {
-          "text": "some real text",
-          "lemmas": "lemma text",
-          "regest": "regest text",
+          "text": "Martyrarius Hüter eines Märtyrergrabes, Reliquienhüter. Seit der ersten Hälfte des 6. Jahrhunderts belegt, scheint es sich beim martyrarius um einen Geistlichen gehandelt zu haben, dem die Fürsorge für ein Märtyrergrab oblag. Könnte es sich dabei zunächst noch um ein spezielles Amt gehandelt haben, so scheint martyrarius bald eine besondere Funktion zu bezeichnen, die verschiedene Amtsträger wie etwa Diakone oder Äbte innehaben konnten. HL",
+          "lemmas": null,
+          "regest": null,
           "title": "Martyrarius",
           "urn": "urn:cts:formulae:elexicon.martyrarius.deu001",
           "date_string": " ",
           "comp_ort": " ",
-          "autocomplete": "autocomplete text",
-          "autocomplete_lemmas": "autocomplete lemma text",
-          "autocomplete_regest": "autocomplete regest text",
+          "autocomplete": "Martyrarius Hüter eines Märtyrergrabes, Reliquienhüter. Seit der ersten Hälfte des 6. Jahrhunderts belegt, scheint es sich beim martyrarius um einen Geistlichen gehandelt zu haben, dem die Fürsorge für ein Märtyrergrab oblag. Könnte es sich dabei zunächst noch um ein spezielles Amt gehandelt haben, so scheint martyrarius bald eine besondere Funktion zu bezeichnen, die verschiedene Amtsträger wie etwa Diakone oder Äbte innehaben konnten. HL",
+          "autocomplete_lemmas": null,
+          "autocomplete_regest": null,
           "orig_comp_ort": " ",
           "collection": "elexicon",
           "forgery": false,
@@ -99,7 +103,7 @@
         },
         "highlight": {
           "text": [
-            "text"
+            "scheint martyrarius bald eine besondere Funktion zu bezeichnen, die verschiedene Amtsträger wie etwa </small><strong>Diakone</strong><small>"
           ]
         },
         "sort": [
@@ -113,16 +117,16 @@
         "_id": "urn:cts:formulae:elexicon.vir_venerabilis.deu001",
         "_score": null,
         "_source": {
-          "text": "some real text",
-          "lemmas": "lemma text",
-          "regest": "regest text",
+          "text": "Vir venerabilis: wörtlich „ehrwürdiger Mann“. Seit der Spätantike war der Ehrentitel des vir venerabilis in erster Linie Bischöfen vorbehalten Spätestens seit dem Ende des 6. Jahrhunderts erhielten auch Äbte diese Titulatur In den merowingischen Königsurkunden zeigt sich die Tendenz nur den Abt auf diese Weise zu bezeichnen, während der Bischof in der Regel mit dem Ehrentitel vir apostolicus versehen wird. In wenigen Ausnahmefällen werden auch Diakone oder Kleriker als viri venerabiles bezeichnet jedoch stehen die jeweiligen Personen, sofern dies nachzuvollziehen ist, stets in Verbindung zu Abbatiat oder Bischofsamt In der Folgezeit scheint sich die Verwendung der Titulatur für Äbte und Bischöfe durchgesetzt zu haben Die Verwendung des adjektivischen Epithetons venerabilis das seit der Spätantike ähnlich wie sanctus „heilig“) als Ausdruck der Ehrerweisung für Geistliche jeden Ranges und auch für Weltliche (z. B. für den Kaiser) gebraucht wurde, ist von dieser Titulatur abzugrenzen In der zweiten Hälfte des 9. Jahrhunderts wird der Gebrauch des Zusatzes vir aufgegeben AM",
+          "lemmas": null,
+          "regest": null,
           "title": "Vir venerabilis:",
           "urn": "urn:cts:formulae:elexicon.vir_venerabilis.deu001",
           "date_string": " ",
           "comp_ort": " ",
-          "autocomplete": "autocomplete text",
-          "autocomplete_lemmas": "autocomplete lemma text",
-          "autocomplete_regest": "autocomplete regest text",
+          "autocomplete": "Vir venerabilis: wörtlich „ehrwürdiger Mann“. Seit der Spätantike war der Ehrentitel des vir venerabilis in erster Linie Bischöfen vorbehalten Spätestens seit dem Ende des 6. Jahrhunderts erhielten auch Äbte diese Titulatur In den merowingischen Königsurkunden zeigt sich die Tendenz nur den Abt auf diese Weise zu bezeichnen, während der Bischof in der Regel mit dem Ehrentitel vir apostolicus versehen wird. In wenigen Ausnahmefällen werden auch Diakone oder Kleriker als viri venerabiles bezeichnet jedoch stehen die jeweiligen Personen, sofern dies nachzuvollziehen ist, stets in Verbindung zu Abbatiat oder Bischofsamt In der Folgezeit scheint sich die Verwendung der Titulatur für Äbte und Bischöfe durchgesetzt zu haben Die Verwendung des adjektivischen Epithetons venerabilis das seit der Spätantike ähnlich wie sanctus „heilig“) als Ausdruck der Ehrerweisung für Geistliche jeden Ranges und auch für Weltliche (z. B. für den Kaiser) gebraucht wurde, ist von dieser Titulatur abzugrenzen In der zweiten Hälfte des 9. Jahrhunderts wird der Gebrauch des Zusatzes vir aufgegeben AM",
+          "autocomplete_lemmas": null,
+          "autocomplete_regest": null,
           "orig_comp_ort": " ",
           "collection": "elexicon",
           "forgery": false,
@@ -130,7 +134,7 @@
         },
         "highlight": {
           "text": [
-            "text"
+            "In wenigen Ausnahmefällen werden auch </small><strong>Diakone</strong><small> oder Kleriker als viri venerabiles bezeichnet jedoch stehen"
           ]
         },
         "sort": [

--- a/tests/test_data/advanced_search/__mocks__/_search/elexicon&False&diakone&0&False&0&0&0&0&0&0&0&0&0&0&0&False&&urn&&&regest&&&include&False&&simple_resp.json
+++ b/tests/test_data/advanced_search/__mocks__/_search/elexicon&False&diakone&0&False&0&0&0&0&0&0&0&0&0&0&0&False&&urn&&&regest&&&include&False&&simple_resp.json
@@ -20,16 +20,16 @@
         "_id": "urn:cts:formulae:elexicon.diaconus.deu001",
         "_score": null,
         "_source": {
-          "text": "some real text",
-          "lemmas": "lemma text",
-          "regest": "regest text",
+          "text": "Diaconus Diakon, kirchliches Amt des dritten Weihegrades. Der Begriff Diakon scheint aus jüdischer und hellenistisch-römischer Tradition zu stammen, ohne dass sich näheres über seine Herkunft feststellen ließe. Diakone sind bereits bei Paulus bezeugt (Phil. 1, 1) und erscheinen im Neuen Testament als Diener und Gehilfen der Apostel. In der Frühzeit der Kirche wurden Diakone gemeinsam mit den Bischöfen von der Gemeinde gewählt, waren diesen als Helfer zugeordnet und zunächst mit dem Vollzug der Liturgie betraut. Aus der Nähe zum Bischof resultierte bald die Übernahme administrativer Tätigkeiten bis hin zur Stellvertretung desselben. Mit dem Konzil von Nicäa 325 wurden die Diakone innerhalb des Klerus hinter den Presbytern eingestuft. Sie erhielten fortan zwar eine Weihe dritten Grades, gehörten aber nicht dem Priesterstand an. Zugleich wurden ihre Kompetenzen eingeschränkt und ihre Aufgaben hinsichtlich der Liturgie präzisiert. In der Merowingerzeit traten Diakone auch in der Funktion des aedituus Pförtner, Küstner, Sakristan oder Messner) einer basilica auf. Neben Diakonen sind in der frühen Kirche auch Diakoninnen bezeugt. Im 4. und 5. Jahrhundert im Westen auf Konzilien verurteilt, finden sich in der Folge nur sehr wenige Nennungen von Diakoninnen, bei denen es sich jedoch auch um einen Ehrentitel oder die Ehefrau des Diakons handeln konnte. Das Amt des archidiaconus entstand wohl im 5. Jahrhundert. Seit dem 6. Jahrhundert gehörten diese immer zu einer Bischofskirche und waren für die Ausbildung und Aufrechterhaltung der Disziplin der Kleriker zuständig. Bis Mitte des 9. Jahrhunderts stiegen die archidiaconi zu den wichtigsten Mitarbeitern der Bischöfe auf. Im hohen und späten Mittelalter war die Machtfülle einiger Diakone offenbar so angewachsen, dass sie die Position ihrer Bischöfe bedrohen konnten. HL",
+          "lemmas": null,
+          "regest": null,
           "title": "Diaconus",
           "urn": "urn:cts:formulae:elexicon.diaconus.deu001",
           "date_string": " ",
           "comp_ort": " ",
-          "autocomplete": "autocomplete text",
-          "autocomplete_lemmas": "autocomplete lemma text",
-          "autocomplete_regest": "autocomplete regest text",
+          "autocomplete": "Diaconus Diakon, kirchliches Amt des dritten Weihegrades. Der Begriff Diakon scheint aus jüdischer und hellenistisch-römischer Tradition zu stammen, ohne dass sich näheres über seine Herkunft feststellen ließe. Diakone sind bereits bei Paulus bezeugt (Phil. 1, 1) und erscheinen im Neuen Testament als Diener und Gehilfen der Apostel. In der Frühzeit der Kirche wurden Diakone gemeinsam mit den Bischöfen von der Gemeinde gewählt, waren diesen als Helfer zugeordnet und zunächst mit dem Vollzug der Liturgie betraut. Aus der Nähe zum Bischof resultierte bald die Übernahme administrativer Tätigkeiten bis hin zur Stellvertretung desselben. Mit dem Konzil von Nicäa 325 wurden die Diakone innerhalb des Klerus hinter den Presbytern eingestuft. Sie erhielten fortan zwar eine Weihe dritten Grades, gehörten aber nicht dem Priesterstand an. Zugleich wurden ihre Kompetenzen eingeschränkt und ihre Aufgaben hinsichtlich der Liturgie präzisiert. In der Merowingerzeit traten Diakone auch in der Funktion des aedituus Pförtner, Küstner, Sakristan oder Messner) einer basilica auf. Neben Diakonen sind in der frühen Kirche auch Diakoninnen bezeugt. Im 4. und 5. Jahrhundert im Westen auf Konzilien verurteilt, finden sich in der Folge nur sehr wenige Nennungen von Diakoninnen, bei denen es sich jedoch auch um einen Ehrentitel oder die Ehefrau des Diakons handeln konnte. Das Amt des archidiaconus entstand wohl im 5. Jahrhundert. Seit dem 6. Jahrhundert gehörten diese immer zu einer Bischofskirche und waren für die Ausbildung und Aufrechterhaltung der Disziplin der Kleriker zuständig. Bis Mitte des 9. Jahrhunderts stiegen die archidiaconi zu den wichtigsten Mitarbeitern der Bischöfe auf. Im hohen und späten Mittelalter war die Machtfülle einiger Diakone offenbar so angewachsen, dass sie die Position ihrer Bischöfe bedrohen konnten. HL",
+          "autocomplete_lemmas": null,
+          "autocomplete_regest": null,
           "orig_comp_ort": " ",
           "collection": "elexicon",
           "forgery": false,
@@ -37,7 +37,11 @@
         },
         "highlight": {
           "text": [
-            "text"
+            "</small><strong>Diakone</strong><small> sind bereits bei Paulus bezeugt (Phil. 1, 1) und erscheinen im Neuen Testament als Diener und",
+            "In der Frühzeit der Kirche wurden </small><strong>Diakone</strong><small> gemeinsam mit den Bischöfen von der Gemeinde gewählt, waren",
+            "Mit dem Konzil von Nicäa 325 wurden die </small><strong>Diakone</strong><small> innerhalb des Klerus hinter den Presbytern eingestuft",
+            "In der Merowingerzeit traten </small><strong>Diakone</strong><small> auch in der Funktion des aedituus Pförtner, Küstner, Sakristan oder",
+            "Im hohen und späten Mittelalter war die Machtfülle einiger </small><strong>Diakone</strong><small> offenbar so angewachsen, dass sie"
           ]
         },
         "sort": [
@@ -51,16 +55,16 @@
         "_id": "urn:cts:formulae:elexicon.episcopus.deu001",
         "_score": null,
         "_source": {
-          "text": "some real text",
-          "lemmas": "lemma text",
-          "regest": "regest text",
+          "text": "Episcopus Bischof; aus dem Griechischen ins Lateinische übernommen, wörtlich „Aufseher“. Synonym für episcopus werden auch sacerdos antistes praesul pontifex papa und presbyter gebraucht. Im christlichen Umfeld agierten episcopi zunächst wohl, wie Presbyter und Diakone, als Ratgeber und Vorsteher der Gemeinde. Endgültig zum Leiter einer Gemeinde stieg der episcopus wohl mit der Ausbildung einer bischöflichen Kirchenordnung im 2. -3. Jahrhundert auf. Zunehmend durch kanonische Satzungen geregelt, wurde das Episkopat nunmehr zum höchsten kirchlichen Weihegrad und zum dauerhaften Amt mit fest abgegrenztem Sprengel. Die Bischofswahl sollte in der Spätantike durch die anderen Bischöfe der Provinz unter Berücksichtigung des Willens der Gemeinde erfolgen. Im Frühmittelalter sah das kanonische Recht die Wahl durch populus und Klerus der Gemeinde, unter Mitsprache der Mitbischöfe und des Metropoliten, vor, wurde in der Praxis jedoch häufig durch die Einflussnahme des Herrschers oder des lokalen Adels entschieden. Der Bischof war die zentrale Autorität der Gemeinde; ihm oblagen die Durchführung der zentralen Bestandteile der Liturgie sowie die Aufsicht über die anderen Kleriker. Seit Konstantin dem Großen wurde zudem die bischöfliche Gerichtsbarkeit in bestimmten Fällen anerkannt, die schließlich auch auf die Zivilgerichtsbarkeit ausgedehnt wurde. In fränkischer Zeit übernahmen zahlreiche Bischöfe die Aufgaben der städtischen curia und konnten schließlich als Stellvertreter des Königs fungieren. Nach einer Beschneidung der weltlichen Macht der Bischöfe durch die frühen Karolinger entwickelten sich seit dem 9. Jahrhundert zahlreiche Bischöfe durch die Übertragung von Immunität, Königsschutz und Herrschaftsrechten zu Stadtherren und zentralen Trägern der Königsherrschaft. HL",
+          "lemmas": null,
+          "regest": null,
           "title": "Episcopus",
           "urn": "urn:cts:formulae:elexicon.episcopus.deu001",
           "date_string": " ",
           "comp_ort": " ",
-          "autocomplete": "autocomplete text",
-          "autocomplete_lemmas": "autocomplete lemma text",
-          "autocomplete_regest": "autocomplete regest text",
+          "autocomplete": "Episcopus Bischof; aus dem Griechischen ins Lateinische übernommen, wörtlich „Aufseher“. Synonym für episcopus werden auch sacerdos antistes praesul pontifex papa und presbyter gebraucht. Im christlichen Umfeld agierten episcopi zunächst wohl, wie Presbyter und Diakone, als Ratgeber und Vorsteher der Gemeinde. Endgültig zum Leiter einer Gemeinde stieg der episcopus wohl mit der Ausbildung einer bischöflichen Kirchenordnung im 2. -3. Jahrhundert auf. Zunehmend durch kanonische Satzungen geregelt, wurde das Episkopat nunmehr zum höchsten kirchlichen Weihegrad und zum dauerhaften Amt mit fest abgegrenztem Sprengel. Die Bischofswahl sollte in der Spätantike durch die anderen Bischöfe der Provinz unter Berücksichtigung des Willens der Gemeinde erfolgen. Im Frühmittelalter sah das kanonische Recht die Wahl durch populus und Klerus der Gemeinde, unter Mitsprache der Mitbischöfe und des Metropoliten, vor, wurde in der Praxis jedoch häufig durch die Einflussnahme des Herrschers oder des lokalen Adels entschieden. Der Bischof war die zentrale Autorität der Gemeinde; ihm oblagen die Durchführung der zentralen Bestandteile der Liturgie sowie die Aufsicht über die anderen Kleriker. Seit Konstantin dem Großen wurde zudem die bischöfliche Gerichtsbarkeit in bestimmten Fällen anerkannt, die schließlich auch auf die Zivilgerichtsbarkeit ausgedehnt wurde. In fränkischer Zeit übernahmen zahlreiche Bischöfe die Aufgaben der städtischen curia und konnten schließlich als Stellvertreter des Königs fungieren. Nach einer Beschneidung der weltlichen Macht der Bischöfe durch die frühen Karolinger entwickelten sich seit dem 9. Jahrhundert zahlreiche Bischöfe durch die Übertragung von Immunität, Königsschutz und Herrschaftsrechten zu Stadtherren und zentralen Trägern der Königsherrschaft. HL",
+          "autocomplete_lemmas": null,
+          "autocomplete_regest": null,
           "orig_comp_ort": " ",
           "collection": "elexicon",
           "forgery": false,
@@ -68,7 +72,7 @@
         },
         "highlight": {
           "text": [
-            "text"
+            "Im christlichen Umfeld agierten episcopi zunächst wohl, wie Presbyter und </small><strong>Diakone</strong><small>, als Ratgeber und Vorsteher"
           ]
         },
         "sort": [
@@ -82,16 +86,16 @@
         "_id": "urn:cts:formulae:elexicon.martyrarius.deu001",
         "_score": null,
         "_source": {
-          "text": "some real text",
-          "lemmas": "lemma text",
-          "regest": "regest text",
+          "text": "Martyrarius Hüter eines Märtyrergrabes, Reliquienhüter. Seit der ersten Hälfte des 6. Jahrhunderts belegt, scheint es sich beim martyrarius um einen Geistlichen gehandelt zu haben, dem die Fürsorge für ein Märtyrergrab oblag. Könnte es sich dabei zunächst noch um ein spezielles Amt gehandelt haben, so scheint martyrarius bald eine besondere Funktion zu bezeichnen, die verschiedene Amtsträger wie etwa Diakone oder Äbte innehaben konnten. HL",
+          "lemmas": null,
+          "regest": null,
           "title": "Martyrarius",
           "urn": "urn:cts:formulae:elexicon.martyrarius.deu001",
           "date_string": " ",
           "comp_ort": " ",
-          "autocomplete": "autocomplete text",
-          "autocomplete_lemmas": "autocomplete lemma text",
-          "autocomplete_regest": "autocomplete regest text",
+          "autocomplete": "Martyrarius Hüter eines Märtyrergrabes, Reliquienhüter. Seit der ersten Hälfte des 6. Jahrhunderts belegt, scheint es sich beim martyrarius um einen Geistlichen gehandelt zu haben, dem die Fürsorge für ein Märtyrergrab oblag. Könnte es sich dabei zunächst noch um ein spezielles Amt gehandelt haben, so scheint martyrarius bald eine besondere Funktion zu bezeichnen, die verschiedene Amtsträger wie etwa Diakone oder Äbte innehaben konnten. HL",
+          "autocomplete_lemmas": null,
+          "autocomplete_regest": null,
           "orig_comp_ort": " ",
           "collection": "elexicon",
           "forgery": false,
@@ -99,7 +103,7 @@
         },
         "highlight": {
           "text": [
-            "text"
+            "scheint martyrarius bald eine besondere Funktion zu bezeichnen, die verschiedene Amtsträger wie etwa </small><strong>Diakone</strong><small>"
           ]
         },
         "sort": [
@@ -113,16 +117,16 @@
         "_id": "urn:cts:formulae:elexicon.vir_venerabilis.deu001",
         "_score": null,
         "_source": {
-          "text": "some real text",
-          "lemmas": "lemma text",
-          "regest": "regest text",
+          "text": "Vir venerabilis: wörtlich „ehrwürdiger Mann“. Seit der Spätantike war der Ehrentitel des vir venerabilis in erster Linie Bischöfen vorbehalten Spätestens seit dem Ende des 6. Jahrhunderts erhielten auch Äbte diese Titulatur In den merowingischen Königsurkunden zeigt sich die Tendenz nur den Abt auf diese Weise zu bezeichnen, während der Bischof in der Regel mit dem Ehrentitel vir apostolicus versehen wird. In wenigen Ausnahmefällen werden auch Diakone oder Kleriker als viri venerabiles bezeichnet jedoch stehen die jeweiligen Personen, sofern dies nachzuvollziehen ist, stets in Verbindung zu Abbatiat oder Bischofsamt In der Folgezeit scheint sich die Verwendung der Titulatur für Äbte und Bischöfe durchgesetzt zu haben Die Verwendung des adjektivischen Epithetons venerabilis das seit der Spätantike ähnlich wie sanctus „heilig“) als Ausdruck der Ehrerweisung für Geistliche jeden Ranges und auch für Weltliche (z. B. für den Kaiser) gebraucht wurde, ist von dieser Titulatur abzugrenzen In der zweiten Hälfte des 9. Jahrhunderts wird der Gebrauch des Zusatzes vir aufgegeben AM",
+          "lemmas": null,
+          "regest": null,
           "title": "Vir venerabilis:",
           "urn": "urn:cts:formulae:elexicon.vir_venerabilis.deu001",
           "date_string": " ",
           "comp_ort": " ",
-          "autocomplete": "autocomplete text",
-          "autocomplete_lemmas": "autocomplete lemma text",
-          "autocomplete_regest": "autocomplete regest text",
+          "autocomplete": "Vir venerabilis: wörtlich „ehrwürdiger Mann“. Seit der Spätantike war der Ehrentitel des vir venerabilis in erster Linie Bischöfen vorbehalten Spätestens seit dem Ende des 6. Jahrhunderts erhielten auch Äbte diese Titulatur In den merowingischen Königsurkunden zeigt sich die Tendenz nur den Abt auf diese Weise zu bezeichnen, während der Bischof in der Regel mit dem Ehrentitel vir apostolicus versehen wird. In wenigen Ausnahmefällen werden auch Diakone oder Kleriker als viri venerabiles bezeichnet jedoch stehen die jeweiligen Personen, sofern dies nachzuvollziehen ist, stets in Verbindung zu Abbatiat oder Bischofsamt In der Folgezeit scheint sich die Verwendung der Titulatur für Äbte und Bischöfe durchgesetzt zu haben Die Verwendung des adjektivischen Epithetons venerabilis das seit der Spätantike ähnlich wie sanctus „heilig“) als Ausdruck der Ehrerweisung für Geistliche jeden Ranges und auch für Weltliche (z. B. für den Kaiser) gebraucht wurde, ist von dieser Titulatur abzugrenzen In der zweiten Hälfte des 9. Jahrhunderts wird der Gebrauch des Zusatzes vir aufgegeben AM",
+          "autocomplete_lemmas": null,
+          "autocomplete_regest": null,
           "orig_comp_ort": " ",
           "collection": "elexicon",
           "forgery": false,
@@ -130,7 +134,7 @@
         },
         "highlight": {
           "text": [
-            "text"
+            "In wenigen Ausnahmefällen werden auch </small><strong>Diakone</strong><small> oder Kleriker als viri venerabiles bezeichnet jedoch stehen"
           ]
         },
         "sort": [

--- a/tests/test_data/advanced_search/__mocks__/_search/elexicon&False&diakone+märtyrergrab&0&False&0&0&0&0&0&0&0&0&0&0&0&False&&urn&&&regest&&&include&False&&advanced_resp.json
+++ b/tests/test_data/advanced_search/__mocks__/_search/elexicon&False&diakone+märtyrergrab&0&False&0&0&0&0&0&0&0&0&0&0&0&False&&urn&&&regest&&&include&False&&advanced_resp.json
@@ -20,16 +20,16 @@
         "_id": "urn:cts:formulae:elexicon.martyrarius.deu001",
         "_score": null,
         "_source": {
-          "text": "some real text",
-          "lemmas": "lemma text",
-          "regest": "regest text",
+          "text": "Martyrarius Hüter eines Märtyrergrabes, Reliquienhüter. Seit der ersten Hälfte des 6. Jahrhunderts belegt, scheint es sich beim martyrarius um einen Geistlichen gehandelt zu haben, dem die Fürsorge für ein Märtyrergrab oblag. Könnte es sich dabei zunächst noch um ein spezielles Amt gehandelt haben, so scheint martyrarius bald eine besondere Funktion zu bezeichnen, die verschiedene Amtsträger wie etwa Diakone oder Äbte innehaben konnten. HL",
+          "lemmas": null,
+          "regest": null,
           "title": "Martyrarius",
           "urn": "urn:cts:formulae:elexicon.martyrarius.deu001",
           "date_string": " ",
           "comp_ort": " ",
-          "autocomplete": "autocomplete text",
-          "autocomplete_lemmas": "autocomplete lemma text",
-          "autocomplete_regest": "autocomplete regest text",
+          "autocomplete": "Martyrarius Hüter eines Märtyrergrabes, Reliquienhüter. Seit der ersten Hälfte des 6. Jahrhunderts belegt, scheint es sich beim martyrarius um einen Geistlichen gehandelt zu haben, dem die Fürsorge für ein Märtyrergrab oblag. Könnte es sich dabei zunächst noch um ein spezielles Amt gehandelt haben, so scheint martyrarius bald eine besondere Funktion zu bezeichnen, die verschiedene Amtsträger wie etwa Diakone oder Äbte innehaben konnten. HL",
+          "autocomplete_lemmas": null,
+          "autocomplete_regest": null,
           "orig_comp_ort": " ",
           "collection": "elexicon",
           "forgery": false,
@@ -37,7 +37,8 @@
         },
         "highlight": {
           "text": [
-            "text"
+            "scheint es sich beim martyrarius um einen Geistlichen gehandelt zu haben, dem die Fürsorge für ein </small><strong>Märtyrergrab</strong><small>",
+            "scheint martyrarius bald eine besondere Funktion zu bezeichnen, die verschiedene Amtsträger wie etwa </small><strong>Diakone</strong><small>"
           ]
         },
         "sort": [

--- a/tests/test_data/advanced_search/__mocks__/_search/elexicon&False&m?rtyr*&0&False&0&0&0&0&0&0&0&0&0&0&0&False&&urn&&&regest&&&include&False&&advanced_resp.json
+++ b/tests/test_data/advanced_search/__mocks__/_search/elexicon&False&m?rtyr*&0&False&0&0&0&0&0&0&0&0&0&0&0&False&&urn&&&regest&&&include&False&&advanced_resp.json
@@ -1,5 +1,5 @@
 {
-  "took": 2,
+  "took": 1,
   "timed_out": false,
   "_shards": {
     "total": 1,
@@ -20,16 +20,16 @@
         "_id": "urn:cts:formulae:elexicon.abbas.deu001",
         "_score": null,
         "_source": {
-          "text": "some real text",
-          "lemmas": "lemma text",
-          "regest": "regest text",
+          "text": "Abbas, abbatissa Abt, Äbtissin. Aus dem aramäischen abba für Vater, Mönch. Vermutlich bereits in apostolischer Zeit für hervorragende Mitglieder der christlichen Gemeinde gebraucht, wurde abbas im ägyptischen Mönchtum im 4. Jahrhundert zur Bezeichnung für jene Mönche, die Dank ihrer Lebenserfahrung und Tugend als spirituelle Vorbilder und Lehrer dienen konnten. Ohne diese alte Bedeutung vollends zu verlieren, verbreitete sich abbas seit dem 5. Jahrhundert im lateinischen Westen im Rahmen der Organisation des monastischen Lebens als Amtsbezeichnung. Abbates finden sich dabei nicht nur als Klostervorsteher, sondern auch als Stellvertreter von Bischöfen, Leiter von Basiliken mit Märtyrergräbern nebst den dazu gehörenden Klerikergemeinden und auch anderen Kirchen. Maßgeblich für die Entwicklung des Klosterabbatiats wurde die Mönchsregel Benedikts von Nursia († 547). Aufbauend auf früheren Regeln erscheint der Abt bei ihm als Stellvertreter Christi und Vater der Mönche, über welche er nahezu ohne Einschränkungen und Vorbehalt Gewalt ausübt. Scheint der Abt vor Benedikt häufig selbst seinen Nachfolger designiert zu haben, legte die Benediktsregel die (ebenfalls bereits bekannte) Wahl durch die Mönchsgemeinde fest. Zwar finden sich in der Folge wiederholt Bestätigungen des Wahlrechtes, doch wurden zugleich die Rechte der Klostergründer und -eigner wie auch der Bischöfe, den Abt eines Klosters zu ernennen, gestärkt. Von der Merowinger- zur Karolingerzeit wandelt sich die Konzeption von Kloster und Abbatiat. Die Wahrnehmung des materiellen Wertes der Klöster trat verstärkt neben die seiner religiösen Ziele. Äbte wurden nun dem hohen Klerus zugerechnet, entwickelten sich zu eigenen Herrschaftsträgern und fanden sich verstärkt im Umfeld der Könige, die nun auch selbst Äbte einsetzten. Mit diesem Wandel einher ging die Ausweitung der Übernahme von Abbatiaten durch Laien, Kleriker, Kanoniker und Bischöfe und damit die Loslösung des Abtsamtes vom inneren Leben des Klosters. Eine Umkehr dieser Entwicklung begann schließlich mit den Reformbewegungen des 10. Jahrhunderts. HL",
+          "lemmas": null,
+          "regest": null,
           "title": "Abbas, abbatissa",
           "urn": "urn:cts:formulae:elexicon.abbas.deu001",
           "date_string": " ",
           "comp_ort": " ",
-          "autocomplete": "autocomplete text",
-          "autocomplete_lemmas": "autocomplete lemma text",
-          "autocomplete_regest": "autocomplete regest text",
+          "autocomplete": "Abbas, abbatissa Abt, Äbtissin. Aus dem aramäischen abba für Vater, Mönch. Vermutlich bereits in apostolischer Zeit für hervorragende Mitglieder der christlichen Gemeinde gebraucht, wurde abbas im ägyptischen Mönchtum im 4. Jahrhundert zur Bezeichnung für jene Mönche, die Dank ihrer Lebenserfahrung und Tugend als spirituelle Vorbilder und Lehrer dienen konnten. Ohne diese alte Bedeutung vollends zu verlieren, verbreitete sich abbas seit dem 5. Jahrhundert im lateinischen Westen im Rahmen der Organisation des monastischen Lebens als Amtsbezeichnung. Abbates finden sich dabei nicht nur als Klostervorsteher, sondern auch als Stellvertreter von Bischöfen, Leiter von Basiliken mit Märtyrergräbern nebst den dazu gehörenden Klerikergemeinden und auch anderen Kirchen. Maßgeblich für die Entwicklung des Klosterabbatiats wurde die Mönchsregel Benedikts von Nursia († 547). Aufbauend auf früheren Regeln erscheint der Abt bei ihm als Stellvertreter Christi und Vater der Mönche, über welche er nahezu ohne Einschränkungen und Vorbehalt Gewalt ausübt. Scheint der Abt vor Benedikt häufig selbst seinen Nachfolger designiert zu haben, legte die Benediktsregel die (ebenfalls bereits bekannte) Wahl durch die Mönchsgemeinde fest. Zwar finden sich in der Folge wiederholt Bestätigungen des Wahlrechtes, doch wurden zugleich die Rechte der Klostergründer und -eigner wie auch der Bischöfe, den Abt eines Klosters zu ernennen, gestärkt. Von der Merowinger- zur Karolingerzeit wandelt sich die Konzeption von Kloster und Abbatiat. Die Wahrnehmung des materiellen Wertes der Klöster trat verstärkt neben die seiner religiösen Ziele. Äbte wurden nun dem hohen Klerus zugerechnet, entwickelten sich zu eigenen Herrschaftsträgern und fanden sich verstärkt im Umfeld der Könige, die nun auch selbst Äbte einsetzten. Mit diesem Wandel einher ging die Ausweitung der Übernahme von Abbatiaten durch Laien, Kleriker, Kanoniker und Bischöfe und damit die Loslösung des Abtsamtes vom inneren Leben des Klosters. Eine Umkehr dieser Entwicklung begann schließlich mit den Reformbewegungen des 10. Jahrhunderts. HL",
+          "autocomplete_lemmas": null,
+          "autocomplete_regest": null,
           "orig_comp_ort": " ",
           "collection": "elexicon",
           "forgery": false,
@@ -37,7 +37,7 @@
         },
         "highlight": {
           "text": [
-            "text"
+            "nicht nur als Klostervorsteher, sondern auch als Stellvertreter von Bischöfen, Leiter von Basiliken mit </small><strong>Märtyrergräbern</strong><small>"
           ]
         },
         "sort": [
@@ -51,16 +51,16 @@
         "_id": "urn:cts:formulae:elexicon.abbatissa.deu001",
         "_score": null,
         "_source": {
-          "text": "some real text",
-          "lemmas": "lemma text",
-          "regest": "regest text",
+          "text": "Abbas, abbatissa Abt, Äbtissin. Aus dem aramäischen abba für Vater, Mönch. Vermutlich bereits in apostolischer Zeit für hervorragende Mitglieder der christlichen Gemeinde gebraucht, wurde abbas im ägyptischen Mönchtum im 4. Jahrhundert zur Bezeichnung für jene Mönche, die Dank ihrer Lebenserfahrung und Tugend als spirituelle Vorbilder und Lehrer dienen konnten. Ohne diese alte Bedeutung vollends zu verlieren, verbreitete sich abbas seit dem 5. Jahrhundert im lateinischen Westen im Rahmen der Organisation des monastischen Lebens als Amtsbezeichnung. Abbates finden sich dabei nicht nur als Klostervorsteher, sondern auch als Stellvertreter von Bischöfen, Leiter von Basiliken mit Märtyrergräbern nebst den dazu gehörenden Klerikergemeinden und auch anderen Kirchen. Maßgeblich für die Entwicklung des Klosterabbatiats wurde die Mönchsregel Benedikts von Nursia († 547). Aufbauend auf früheren Regeln erscheint der Abt bei ihm als Stellvertreter Christi und Vater der Mönche, über welche er nahezu ohne Einschränkungen und Vorbehalt Gewalt ausübt. Scheint der Abt vor Benedikt häufig selbst seinen Nachfolger designiert zu haben, legte die Benediktsregel die (ebenfalls bereits bekannte) Wahl durch die Mönchsgemeinde fest. Zwar finden sich in der Folge wiederholt Bestätigungen des Wahlrechtes, doch wurden zugleich die Rechte der Klostergründer und -eigner wie auch der Bischöfe, den Abt eines Klosters zu ernennen, gestärkt. Von der Merowinger- zur Karolingerzeit wandelt sich die Konzeption von Kloster und Abbatiat. Die Wahrnehmung des materiellen Wertes der Klöster trat verstärkt neben die seiner religiösen Ziele. Äbte wurden nun dem hohen Klerus zugerechnet, entwickelten sich zu eigenen Herrschaftsträgern und fanden sich verstärkt im Umfeld der Könige, die nun auch selbst Äbte einsetzten. Mit diesem Wandel einher ging die Ausweitung der Übernahme von Abbatiaten durch Laien, Kleriker, Kanoniker und Bischöfe und damit die Loslösung des Abtsamtes vom inneren Leben des Klosters. Eine Umkehr dieser Entwicklung begann schließlich mit den Reformbewegungen des 10. Jahrhunderts. HL",
+          "lemmas": null,
+          "regest": null,
           "title": "Abbas, abbatissa",
           "urn": "urn:cts:formulae:elexicon.abbatissa.deu001",
           "date_string": " ",
           "comp_ort": " ",
-          "autocomplete": "autocomplete text",
-          "autocomplete_lemmas": "autocomplete lemma text",
-          "autocomplete_regest": "autocomplete regest text",
+          "autocomplete": "Abbas, abbatissa Abt, Äbtissin. Aus dem aramäischen abba für Vater, Mönch. Vermutlich bereits in apostolischer Zeit für hervorragende Mitglieder der christlichen Gemeinde gebraucht, wurde abbas im ägyptischen Mönchtum im 4. Jahrhundert zur Bezeichnung für jene Mönche, die Dank ihrer Lebenserfahrung und Tugend als spirituelle Vorbilder und Lehrer dienen konnten. Ohne diese alte Bedeutung vollends zu verlieren, verbreitete sich abbas seit dem 5. Jahrhundert im lateinischen Westen im Rahmen der Organisation des monastischen Lebens als Amtsbezeichnung. Abbates finden sich dabei nicht nur als Klostervorsteher, sondern auch als Stellvertreter von Bischöfen, Leiter von Basiliken mit Märtyrergräbern nebst den dazu gehörenden Klerikergemeinden und auch anderen Kirchen. Maßgeblich für die Entwicklung des Klosterabbatiats wurde die Mönchsregel Benedikts von Nursia († 547). Aufbauend auf früheren Regeln erscheint der Abt bei ihm als Stellvertreter Christi und Vater der Mönche, über welche er nahezu ohne Einschränkungen und Vorbehalt Gewalt ausübt. Scheint der Abt vor Benedikt häufig selbst seinen Nachfolger designiert zu haben, legte die Benediktsregel die (ebenfalls bereits bekannte) Wahl durch die Mönchsgemeinde fest. Zwar finden sich in der Folge wiederholt Bestätigungen des Wahlrechtes, doch wurden zugleich die Rechte der Klostergründer und -eigner wie auch der Bischöfe, den Abt eines Klosters zu ernennen, gestärkt. Von der Merowinger- zur Karolingerzeit wandelt sich die Konzeption von Kloster und Abbatiat. Die Wahrnehmung des materiellen Wertes der Klöster trat verstärkt neben die seiner religiösen Ziele. Äbte wurden nun dem hohen Klerus zugerechnet, entwickelten sich zu eigenen Herrschaftsträgern und fanden sich verstärkt im Umfeld der Könige, die nun auch selbst Äbte einsetzten. Mit diesem Wandel einher ging die Ausweitung der Übernahme von Abbatiaten durch Laien, Kleriker, Kanoniker und Bischöfe und damit die Loslösung des Abtsamtes vom inneren Leben des Klosters. Eine Umkehr dieser Entwicklung begann schließlich mit den Reformbewegungen des 10. Jahrhunderts. HL",
+          "autocomplete_lemmas": null,
+          "autocomplete_regest": null,
           "orig_comp_ort": " ",
           "collection": "elexicon",
           "forgery": false,
@@ -68,7 +68,7 @@
         },
         "highlight": {
           "text": [
-            "text"
+            "nicht nur als Klostervorsteher, sondern auch als Stellvertreter von Bischöfen, Leiter von Basiliken mit </small><strong>Märtyrergräbern</strong><small>"
           ]
         },
         "sort": [
@@ -82,16 +82,16 @@
         "_id": "urn:cts:formulae:elexicon.martyrarius.deu001",
         "_score": null,
         "_source": {
-          "text": "some real text",
-          "lemmas": "lemma text",
-          "regest": "regest text",
+          "text": "Martyrarius Hüter eines Märtyrergrabes, Reliquienhüter. Seit der ersten Hälfte des 6. Jahrhunderts belegt, scheint es sich beim martyrarius um einen Geistlichen gehandelt zu haben, dem die Fürsorge für ein Märtyrergrab oblag. Könnte es sich dabei zunächst noch um ein spezielles Amt gehandelt haben, so scheint martyrarius bald eine besondere Funktion zu bezeichnen, die verschiedene Amtsträger wie etwa Diakone oder Äbte innehaben konnten. HL",
+          "lemmas": null,
+          "regest": null,
           "title": "Martyrarius",
           "urn": "urn:cts:formulae:elexicon.martyrarius.deu001",
           "date_string": " ",
           "comp_ort": " ",
-          "autocomplete": "autocomplete text",
-          "autocomplete_lemmas": "autocomplete lemma text",
-          "autocomplete_regest": "autocomplete regest text",
+          "autocomplete": "Martyrarius Hüter eines Märtyrergrabes, Reliquienhüter. Seit der ersten Hälfte des 6. Jahrhunderts belegt, scheint es sich beim martyrarius um einen Geistlichen gehandelt zu haben, dem die Fürsorge für ein Märtyrergrab oblag. Könnte es sich dabei zunächst noch um ein spezielles Amt gehandelt haben, so scheint martyrarius bald eine besondere Funktion zu bezeichnen, die verschiedene Amtsträger wie etwa Diakone oder Äbte innehaben konnten. HL",
+          "autocomplete_lemmas": null,
+          "autocomplete_regest": null,
           "orig_comp_ort": " ",
           "collection": "elexicon",
           "forgery": false,
@@ -99,7 +99,10 @@
         },
         "highlight": {
           "text": [
-            "text"
+            "</small><strong>Martyrarius</strong><small> Hüter eines </small><strong>Märtyrergrabes</strong><small>, Reliquienhüter. Seit der ersten Hälfte des 6.",
+            "Jahrhunderts belegt, scheint es sich beim </small><strong>martyrarius</strong><small> um einen Geistlichen gehandelt zu haben, dem die",
+            "Fürsorge für ein </small><strong>Märtyrergrab</strong><small> oblag.",
+            "Könnte es sich dabei zunächst noch um ein spezielles Amt gehandelt haben, so scheint </small><strong>martyrarius</strong><small> bald"
           ]
         },
         "sort": [

--- a/tests/test_data/advanced_search/__mocks__/_search/elexicon&False&m?rtyr*&0&False&0&0&0&0&0&0&0&0&0&0&0&False&&urn&&&regest&&&include&False&&simple_resp.json
+++ b/tests/test_data/advanced_search/__mocks__/_search/elexicon&False&m?rtyr*&0&False&0&0&0&0&0&0&0&0&0&0&0&False&&urn&&&regest&&&include&False&&simple_resp.json
@@ -1,5 +1,5 @@
 {
-  "took": 2,
+  "took": 1,
   "timed_out": false,
   "_shards": {
     "total": 1,
@@ -20,16 +20,16 @@
         "_id": "urn:cts:formulae:elexicon.abbas.deu001",
         "_score": null,
         "_source": {
-          "text": "some real text",
-          "lemmas": "lemma text",
-          "regest": "regest text",
+          "text": "Abbas, abbatissa Abt, Äbtissin. Aus dem aramäischen abba für Vater, Mönch. Vermutlich bereits in apostolischer Zeit für hervorragende Mitglieder der christlichen Gemeinde gebraucht, wurde abbas im ägyptischen Mönchtum im 4. Jahrhundert zur Bezeichnung für jene Mönche, die Dank ihrer Lebenserfahrung und Tugend als spirituelle Vorbilder und Lehrer dienen konnten. Ohne diese alte Bedeutung vollends zu verlieren, verbreitete sich abbas seit dem 5. Jahrhundert im lateinischen Westen im Rahmen der Organisation des monastischen Lebens als Amtsbezeichnung. Abbates finden sich dabei nicht nur als Klostervorsteher, sondern auch als Stellvertreter von Bischöfen, Leiter von Basiliken mit Märtyrergräbern nebst den dazu gehörenden Klerikergemeinden und auch anderen Kirchen. Maßgeblich für die Entwicklung des Klosterabbatiats wurde die Mönchsregel Benedikts von Nursia († 547). Aufbauend auf früheren Regeln erscheint der Abt bei ihm als Stellvertreter Christi und Vater der Mönche, über welche er nahezu ohne Einschränkungen und Vorbehalt Gewalt ausübt. Scheint der Abt vor Benedikt häufig selbst seinen Nachfolger designiert zu haben, legte die Benediktsregel die (ebenfalls bereits bekannte) Wahl durch die Mönchsgemeinde fest. Zwar finden sich in der Folge wiederholt Bestätigungen des Wahlrechtes, doch wurden zugleich die Rechte der Klostergründer und -eigner wie auch der Bischöfe, den Abt eines Klosters zu ernennen, gestärkt. Von der Merowinger- zur Karolingerzeit wandelt sich die Konzeption von Kloster und Abbatiat. Die Wahrnehmung des materiellen Wertes der Klöster trat verstärkt neben die seiner religiösen Ziele. Äbte wurden nun dem hohen Klerus zugerechnet, entwickelten sich zu eigenen Herrschaftsträgern und fanden sich verstärkt im Umfeld der Könige, die nun auch selbst Äbte einsetzten. Mit diesem Wandel einher ging die Ausweitung der Übernahme von Abbatiaten durch Laien, Kleriker, Kanoniker und Bischöfe und damit die Loslösung des Abtsamtes vom inneren Leben des Klosters. Eine Umkehr dieser Entwicklung begann schließlich mit den Reformbewegungen des 10. Jahrhunderts. HL",
+          "lemmas": null,
+          "regest": null,
           "title": "Abbas, abbatissa",
           "urn": "urn:cts:formulae:elexicon.abbas.deu001",
           "date_string": " ",
           "comp_ort": " ",
-          "autocomplete": "autocomplete text",
-          "autocomplete_lemmas": "autocomplete lemma text",
-          "autocomplete_regest": "autocomplete regest text",
+          "autocomplete": "Abbas, abbatissa Abt, Äbtissin. Aus dem aramäischen abba für Vater, Mönch. Vermutlich bereits in apostolischer Zeit für hervorragende Mitglieder der christlichen Gemeinde gebraucht, wurde abbas im ägyptischen Mönchtum im 4. Jahrhundert zur Bezeichnung für jene Mönche, die Dank ihrer Lebenserfahrung und Tugend als spirituelle Vorbilder und Lehrer dienen konnten. Ohne diese alte Bedeutung vollends zu verlieren, verbreitete sich abbas seit dem 5. Jahrhundert im lateinischen Westen im Rahmen der Organisation des monastischen Lebens als Amtsbezeichnung. Abbates finden sich dabei nicht nur als Klostervorsteher, sondern auch als Stellvertreter von Bischöfen, Leiter von Basiliken mit Märtyrergräbern nebst den dazu gehörenden Klerikergemeinden und auch anderen Kirchen. Maßgeblich für die Entwicklung des Klosterabbatiats wurde die Mönchsregel Benedikts von Nursia († 547). Aufbauend auf früheren Regeln erscheint der Abt bei ihm als Stellvertreter Christi und Vater der Mönche, über welche er nahezu ohne Einschränkungen und Vorbehalt Gewalt ausübt. Scheint der Abt vor Benedikt häufig selbst seinen Nachfolger designiert zu haben, legte die Benediktsregel die (ebenfalls bereits bekannte) Wahl durch die Mönchsgemeinde fest. Zwar finden sich in der Folge wiederholt Bestätigungen des Wahlrechtes, doch wurden zugleich die Rechte der Klostergründer und -eigner wie auch der Bischöfe, den Abt eines Klosters zu ernennen, gestärkt. Von der Merowinger- zur Karolingerzeit wandelt sich die Konzeption von Kloster und Abbatiat. Die Wahrnehmung des materiellen Wertes der Klöster trat verstärkt neben die seiner religiösen Ziele. Äbte wurden nun dem hohen Klerus zugerechnet, entwickelten sich zu eigenen Herrschaftsträgern und fanden sich verstärkt im Umfeld der Könige, die nun auch selbst Äbte einsetzten. Mit diesem Wandel einher ging die Ausweitung der Übernahme von Abbatiaten durch Laien, Kleriker, Kanoniker und Bischöfe und damit die Loslösung des Abtsamtes vom inneren Leben des Klosters. Eine Umkehr dieser Entwicklung begann schließlich mit den Reformbewegungen des 10. Jahrhunderts. HL",
+          "autocomplete_lemmas": null,
+          "autocomplete_regest": null,
           "orig_comp_ort": " ",
           "collection": "elexicon",
           "forgery": false,
@@ -37,7 +37,7 @@
         },
         "highlight": {
           "text": [
-            "text"
+            "nicht nur als Klostervorsteher, sondern auch als Stellvertreter von Bischöfen, Leiter von Basiliken mit </small><strong>Märtyrergräbern</strong><small>"
           ]
         },
         "sort": [
@@ -51,16 +51,16 @@
         "_id": "urn:cts:formulae:elexicon.abbatissa.deu001",
         "_score": null,
         "_source": {
-          "text": "some real text",
-          "lemmas": "lemma text",
-          "regest": "regest text",
+          "text": "Abbas, abbatissa Abt, Äbtissin. Aus dem aramäischen abba für Vater, Mönch. Vermutlich bereits in apostolischer Zeit für hervorragende Mitglieder der christlichen Gemeinde gebraucht, wurde abbas im ägyptischen Mönchtum im 4. Jahrhundert zur Bezeichnung für jene Mönche, die Dank ihrer Lebenserfahrung und Tugend als spirituelle Vorbilder und Lehrer dienen konnten. Ohne diese alte Bedeutung vollends zu verlieren, verbreitete sich abbas seit dem 5. Jahrhundert im lateinischen Westen im Rahmen der Organisation des monastischen Lebens als Amtsbezeichnung. Abbates finden sich dabei nicht nur als Klostervorsteher, sondern auch als Stellvertreter von Bischöfen, Leiter von Basiliken mit Märtyrergräbern nebst den dazu gehörenden Klerikergemeinden und auch anderen Kirchen. Maßgeblich für die Entwicklung des Klosterabbatiats wurde die Mönchsregel Benedikts von Nursia († 547). Aufbauend auf früheren Regeln erscheint der Abt bei ihm als Stellvertreter Christi und Vater der Mönche, über welche er nahezu ohne Einschränkungen und Vorbehalt Gewalt ausübt. Scheint der Abt vor Benedikt häufig selbst seinen Nachfolger designiert zu haben, legte die Benediktsregel die (ebenfalls bereits bekannte) Wahl durch die Mönchsgemeinde fest. Zwar finden sich in der Folge wiederholt Bestätigungen des Wahlrechtes, doch wurden zugleich die Rechte der Klostergründer und -eigner wie auch der Bischöfe, den Abt eines Klosters zu ernennen, gestärkt. Von der Merowinger- zur Karolingerzeit wandelt sich die Konzeption von Kloster und Abbatiat. Die Wahrnehmung des materiellen Wertes der Klöster trat verstärkt neben die seiner religiösen Ziele. Äbte wurden nun dem hohen Klerus zugerechnet, entwickelten sich zu eigenen Herrschaftsträgern und fanden sich verstärkt im Umfeld der Könige, die nun auch selbst Äbte einsetzten. Mit diesem Wandel einher ging die Ausweitung der Übernahme von Abbatiaten durch Laien, Kleriker, Kanoniker und Bischöfe und damit die Loslösung des Abtsamtes vom inneren Leben des Klosters. Eine Umkehr dieser Entwicklung begann schließlich mit den Reformbewegungen des 10. Jahrhunderts. HL",
+          "lemmas": null,
+          "regest": null,
           "title": "Abbas, abbatissa",
           "urn": "urn:cts:formulae:elexicon.abbatissa.deu001",
           "date_string": " ",
           "comp_ort": " ",
-          "autocomplete": "autocomplete text",
-          "autocomplete_lemmas": "autocomplete lemma text",
-          "autocomplete_regest": "autocomplete regest text",
+          "autocomplete": "Abbas, abbatissa Abt, Äbtissin. Aus dem aramäischen abba für Vater, Mönch. Vermutlich bereits in apostolischer Zeit für hervorragende Mitglieder der christlichen Gemeinde gebraucht, wurde abbas im ägyptischen Mönchtum im 4. Jahrhundert zur Bezeichnung für jene Mönche, die Dank ihrer Lebenserfahrung und Tugend als spirituelle Vorbilder und Lehrer dienen konnten. Ohne diese alte Bedeutung vollends zu verlieren, verbreitete sich abbas seit dem 5. Jahrhundert im lateinischen Westen im Rahmen der Organisation des monastischen Lebens als Amtsbezeichnung. Abbates finden sich dabei nicht nur als Klostervorsteher, sondern auch als Stellvertreter von Bischöfen, Leiter von Basiliken mit Märtyrergräbern nebst den dazu gehörenden Klerikergemeinden und auch anderen Kirchen. Maßgeblich für die Entwicklung des Klosterabbatiats wurde die Mönchsregel Benedikts von Nursia († 547). Aufbauend auf früheren Regeln erscheint der Abt bei ihm als Stellvertreter Christi und Vater der Mönche, über welche er nahezu ohne Einschränkungen und Vorbehalt Gewalt ausübt. Scheint der Abt vor Benedikt häufig selbst seinen Nachfolger designiert zu haben, legte die Benediktsregel die (ebenfalls bereits bekannte) Wahl durch die Mönchsgemeinde fest. Zwar finden sich in der Folge wiederholt Bestätigungen des Wahlrechtes, doch wurden zugleich die Rechte der Klostergründer und -eigner wie auch der Bischöfe, den Abt eines Klosters zu ernennen, gestärkt. Von der Merowinger- zur Karolingerzeit wandelt sich die Konzeption von Kloster und Abbatiat. Die Wahrnehmung des materiellen Wertes der Klöster trat verstärkt neben die seiner religiösen Ziele. Äbte wurden nun dem hohen Klerus zugerechnet, entwickelten sich zu eigenen Herrschaftsträgern und fanden sich verstärkt im Umfeld der Könige, die nun auch selbst Äbte einsetzten. Mit diesem Wandel einher ging die Ausweitung der Übernahme von Abbatiaten durch Laien, Kleriker, Kanoniker und Bischöfe und damit die Loslösung des Abtsamtes vom inneren Leben des Klosters. Eine Umkehr dieser Entwicklung begann schließlich mit den Reformbewegungen des 10. Jahrhunderts. HL",
+          "autocomplete_lemmas": null,
+          "autocomplete_regest": null,
           "orig_comp_ort": " ",
           "collection": "elexicon",
           "forgery": false,
@@ -68,7 +68,7 @@
         },
         "highlight": {
           "text": [
-            "text"
+            "nicht nur als Klostervorsteher, sondern auch als Stellvertreter von Bischöfen, Leiter von Basiliken mit </small><strong>Märtyrergräbern</strong><small>"
           ]
         },
         "sort": [
@@ -82,16 +82,16 @@
         "_id": "urn:cts:formulae:elexicon.martyrarius.deu001",
         "_score": null,
         "_source": {
-          "text": "some real text",
-          "lemmas": "lemma text",
-          "regest": "regest text",
+          "text": "Martyrarius Hüter eines Märtyrergrabes, Reliquienhüter. Seit der ersten Hälfte des 6. Jahrhunderts belegt, scheint es sich beim martyrarius um einen Geistlichen gehandelt zu haben, dem die Fürsorge für ein Märtyrergrab oblag. Könnte es sich dabei zunächst noch um ein spezielles Amt gehandelt haben, so scheint martyrarius bald eine besondere Funktion zu bezeichnen, die verschiedene Amtsträger wie etwa Diakone oder Äbte innehaben konnten. HL",
+          "lemmas": null,
+          "regest": null,
           "title": "Martyrarius",
           "urn": "urn:cts:formulae:elexicon.martyrarius.deu001",
           "date_string": " ",
           "comp_ort": " ",
-          "autocomplete": "autocomplete text",
-          "autocomplete_lemmas": "autocomplete lemma text",
-          "autocomplete_regest": "autocomplete regest text",
+          "autocomplete": "Martyrarius Hüter eines Märtyrergrabes, Reliquienhüter. Seit der ersten Hälfte des 6. Jahrhunderts belegt, scheint es sich beim martyrarius um einen Geistlichen gehandelt zu haben, dem die Fürsorge für ein Märtyrergrab oblag. Könnte es sich dabei zunächst noch um ein spezielles Amt gehandelt haben, so scheint martyrarius bald eine besondere Funktion zu bezeichnen, die verschiedene Amtsträger wie etwa Diakone oder Äbte innehaben konnten. HL",
+          "autocomplete_lemmas": null,
+          "autocomplete_regest": null,
           "orig_comp_ort": " ",
           "collection": "elexicon",
           "forgery": false,
@@ -99,7 +99,10 @@
         },
         "highlight": {
           "text": [
-            "text"
+            "</small><strong>Martyrarius</strong><small> Hüter eines </small><strong>Märtyrergrabes</strong><small>, Reliquienhüter. Seit der ersten Hälfte des 6.",
+            "Jahrhunderts belegt, scheint es sich beim </small><strong>martyrarius</strong><small> um einen Geistlichen gehandelt zu haben, dem die",
+            "Fürsorge für ein </small><strong>Märtyrergrab</strong><small> oblag.",
+            "Könnte es sich dabei zunächst noch um ein spezielles Amt gehandelt haben, so scheint </small><strong>martyrarius</strong><small> bald"
           ]
         },
         "sort": [

--- a/tests/test_data/advanced_search/__mocks__/_search/elexicon&autocomplete&abba&0&False&0&0&0&0&0&0&0&0&0&0&0&y&&urn&&&regest&&&include&False&&advanced_aggs.json
+++ b/tests/test_data/advanced_search/__mocks__/_search/elexicon&autocomplete&abba&0&False&0&0&0&0&0&0&0&0&0&0&0&y&&urn&&&regest&&&include&False&&advanced_aggs.json
@@ -1,0 +1,485 @@
+{
+  "aggregations": {
+    "all_docs": {
+      "doc_count": 147,
+      "forgeries": {
+        "doc_count": 0
+      },
+      "corpus": {
+        "buckets": {
+          "<b>Angers</b>: Angers": {
+            "doc_count": 0
+          },
+          "<b>Anjou</b>: Archives d’Anjou": {
+            "doc_count": 0
+          },
+          "<b>Anjou</b>: Chroniques des comtes d’Anjou": {
+            "doc_count": 0
+          },
+          "<b>Arnulfinger</b>: Arnulfinger": {
+            "doc_count": 0
+          },
+          "<b>Auvergne</b>: Auvergne": {
+            "doc_count": 0
+          },
+          "<b>Catalunya</b>: Katalonien": {
+            "doc_count": 0
+          },
+          "<b>Chartae Latinae</b>: Chartae Latinae X": {
+            "doc_count": 0
+          },
+          "<b>Chartae Latinae</b>: Chartae Latinae XI": {
+            "doc_count": 0
+          },
+          "<b>Chartae Latinae</b>: Chartae Latinae XII": {
+            "doc_count": 0
+          },
+          "<b>Chartae Latinae</b>: Chartae Latinae XLVI": {
+            "doc_count": 0
+          },
+          "<b>Chartae Latinae</b>: Chartae Latinae XLVII": {
+            "doc_count": 0
+          },
+          "<b>Dijon</b>: Saint-Bénigne de Dijon": {
+            "doc_count": 0
+          },
+          "<b>E-Lexikon</b>": {
+            "doc_count": 147
+          },
+          "<b>Echternach</b>: Echternach": {
+            "doc_count": 0
+          },
+          "<b>Freising</b>: Freising": {
+            "doc_count": 0
+          },
+          "<b>Fulda</b>: Fulda (Dronke)": {
+            "doc_count": 0
+          },
+          "<b>Fulda</b>: Fulda (Stengel)": {
+            "doc_count": 0
+          },
+          "<b>Gorze</b>: Gorze": {
+            "doc_count": 0
+          },
+          "<b>Graubünden</b>: Bünden": {
+            "doc_count": 0
+          },
+          "<b>Hersfeld</b>: Hersfeld": {
+            "doc_count": 0
+          },
+          "<b>Langobarden</b>: Codice Diplomatico Longobardo": {
+            "doc_count": 0
+          },
+          "<b>Lorsch</b>: Lorsch": {
+            "doc_count": 0
+          },
+          "<b>Luzern</b>: Luzern": {
+            "doc_count": 0
+          },
+          "<b>Marculf</b>: Marculf": {
+            "doc_count": 0
+          },
+          "<b>Merowinger</b>: Merowinger": {
+            "doc_count": 0
+          },
+          "<b>Mondsee</b>: Mondsee": {
+            "doc_count": 0
+          },
+          "<b>Papsturkunden</b>: Papsturkunden Frankreich": {
+            "doc_count": 0
+          },
+          "<b>Passau</b>: Passau": {
+            "doc_count": 0
+          },
+          "<b>Redon</b>: Cartulaire de Redon": {
+            "doc_count": 0
+          },
+          "<b>Regensburg</b>: Regensburg": {
+            "doc_count": 0
+          },
+          "<b>Rheinland</b>: Mittelrheinisch": {
+            "doc_count": 0
+          },
+          "<b>Rheinland</b>: Rheinisch": {
+            "doc_count": 0
+          },
+          "<b>Rätien</b>: Rätien": {
+            "doc_count": 0
+          },
+          "<b>Salzburg</b>: Salzburg": {
+            "doc_count": 0
+          },
+          "<b>Schäftlarn</b>: Schäftlarn": {
+            "doc_count": 0
+          },
+          "<b>St. Gallen</b>: St. Gallen": {
+            "doc_count": 0
+          },
+          "<b>Touraine</b>: Accensement d'une vigne de Marmoutier": {
+            "doc_count": 0
+          },
+          "<b>Touraine</b>: Accord entre Bonneval et Marmoutier": {
+            "doc_count": 0
+          },
+          "<b>Touraine</b>: Cormery (TELMA)": {
+            "doc_count": 0
+          },
+          "<b>Touraine</b>: Eudes": {
+            "doc_count": 0
+          },
+          "<b>Touraine</b>: Fragments de Saint-Julien de Tours": {
+            "doc_count": 0
+          },
+          "<b>Touraine</b>: Marmoutier (TELMA)": {
+            "doc_count": 0
+          },
+          "<b>Touraine</b>: Marmoutier - Dunois": {
+            "doc_count": 0
+          },
+          "<b>Touraine</b>: Marmoutier - Fougères": {
+            "doc_count": 0
+          },
+          "<b>Touraine</b>: Marmoutier - Manceau": {
+            "doc_count": 0
+          },
+          "<b>Touraine</b>: Marmoutier - Pour le perche": {
+            "doc_count": 0
+          },
+          "<b>Touraine</b>: Marmoutier - Serfs": {
+            "doc_count": 0
+          },
+          "<b>Touraine</b>: Marmoutier - Trois actes faux ou interpolés": {
+            "doc_count": 0
+          },
+          "<b>Touraine</b>: Marmoutier - Vendômois": {
+            "doc_count": 0
+          },
+          "<b>Touraine</b>: Marmoutier - Vendômois, Appendix": {
+            "doc_count": 0
+          },
+          "<b>Touraine</b>: Marmoutier Cartulaire blésois": {
+            "doc_count": 0
+          },
+          "<b>Touraine</b>: Saint-Martin de Tours (TELMA)": {
+            "doc_count": 0
+          },
+          "<b>Touraine</b>: Un acte faux de Marmoutier": {
+            "doc_count": 0
+          },
+          "<b>Touraine</b>: Une nouvelle charte de Théotolon": {
+            "doc_count": 0
+          },
+          "<b>Werden</b>: Werden": {
+            "doc_count": 0
+          },
+          "<b>Wissembourg</b>: Weißenburg": {
+            "doc_count": 0
+          },
+          "<b>Zürich</b>: Zürich": {
+            "doc_count": 0
+          }
+        }
+      },
+      "range": {
+        "buckets": [
+          {
+            "key": "<499",
+            "from": -62104060800000.0,
+            "from_as_string": "0002",
+            "to": -46420214400000.0,
+            "to_as_string": "0499",
+            "doc_count": 0
+          },
+          {
+            "key": "500-599",
+            "from": -46388678400000.0,
+            "from_as_string": "0500",
+            "to": -43264540800000.0,
+            "to_as_string": "0599",
+            "doc_count": 0
+          },
+          {
+            "key": "600-699",
+            "from": -43233004800000.0,
+            "from_as_string": "0600",
+            "to": -40108867200000.0,
+            "to_as_string": "0699",
+            "doc_count": 0
+          },
+          {
+            "key": "700-799",
+            "from": -40077331200000.0,
+            "from_as_string": "0700",
+            "to": -36953193600000.0,
+            "to_as_string": "0799",
+            "doc_count": 0
+          },
+          {
+            "key": "800-899",
+            "from": -36921657600000.0,
+            "from_as_string": "0800",
+            "to": -33797433600000.0,
+            "to_as_string": "0899",
+            "doc_count": 0
+          },
+          {
+            "key": "900-999",
+            "from": -33765897600000.0,
+            "from_as_string": "0900",
+            "to": -30641760000000.0,
+            "to_as_string": "0999",
+            "doc_count": 0
+          },
+          {
+            "key": ">1000",
+            "from": -30610224000000.0,
+            "from_as_string": "1000",
+            "doc_count": 0
+          }
+        ]
+      },
+      "no_date": {
+        "doc_count": 147
+      }
+    },
+    "forgeries": {
+      "doc_count": 0
+    },
+    "corpus": {
+      "buckets": {
+        "<b>Angers</b>: Angers": {
+          "doc_count": 0
+        },
+        "<b>Anjou</b>: Archives d’Anjou": {
+          "doc_count": 0
+        },
+        "<b>Anjou</b>: Chroniques des comtes d’Anjou": {
+          "doc_count": 0
+        },
+        "<b>Arnulfinger</b>: Arnulfinger": {
+          "doc_count": 0
+        },
+        "<b>Auvergne</b>: Auvergne": {
+          "doc_count": 0
+        },
+        "<b>Catalunya</b>: Katalonien": {
+          "doc_count": 0
+        },
+        "<b>Chartae Latinae</b>: Chartae Latinae X": {
+          "doc_count": 0
+        },
+        "<b>Chartae Latinae</b>: Chartae Latinae XI": {
+          "doc_count": 0
+        },
+        "<b>Chartae Latinae</b>: Chartae Latinae XII": {
+          "doc_count": 0
+        },
+        "<b>Chartae Latinae</b>: Chartae Latinae XLVI": {
+          "doc_count": 0
+        },
+        "<b>Chartae Latinae</b>: Chartae Latinae XLVII": {
+          "doc_count": 0
+        },
+        "<b>Dijon</b>: Saint-Bénigne de Dijon": {
+          "doc_count": 0
+        },
+        "<b>E-Lexikon</b>": {
+          "doc_count": 4
+        },
+        "<b>Echternach</b>: Echternach": {
+          "doc_count": 0
+        },
+        "<b>Freising</b>: Freising": {
+          "doc_count": 0
+        },
+        "<b>Fulda</b>: Fulda (Dronke)": {
+          "doc_count": 0
+        },
+        "<b>Fulda</b>: Fulda (Stengel)": {
+          "doc_count": 0
+        },
+        "<b>Gorze</b>: Gorze": {
+          "doc_count": 0
+        },
+        "<b>Graubünden</b>: Bünden": {
+          "doc_count": 0
+        },
+        "<b>Hersfeld</b>: Hersfeld": {
+          "doc_count": 0
+        },
+        "<b>Langobarden</b>: Codice Diplomatico Longobardo": {
+          "doc_count": 0
+        },
+        "<b>Lorsch</b>: Lorsch": {
+          "doc_count": 0
+        },
+        "<b>Luzern</b>: Luzern": {
+          "doc_count": 0
+        },
+        "<b>Marculf</b>: Marculf": {
+          "doc_count": 0
+        },
+        "<b>Merowinger</b>: Merowinger": {
+          "doc_count": 0
+        },
+        "<b>Mondsee</b>: Mondsee": {
+          "doc_count": 0
+        },
+        "<b>Papsturkunden</b>: Papsturkunden Frankreich": {
+          "doc_count": 0
+        },
+        "<b>Passau</b>: Passau": {
+          "doc_count": 0
+        },
+        "<b>Redon</b>: Cartulaire de Redon": {
+          "doc_count": 0
+        },
+        "<b>Regensburg</b>: Regensburg": {
+          "doc_count": 0
+        },
+        "<b>Rheinland</b>: Mittelrheinisch": {
+          "doc_count": 0
+        },
+        "<b>Rheinland</b>: Rheinisch": {
+          "doc_count": 0
+        },
+        "<b>Rätien</b>: Rätien": {
+          "doc_count": 0
+        },
+        "<b>Salzburg</b>: Salzburg": {
+          "doc_count": 0
+        },
+        "<b>Schäftlarn</b>: Schäftlarn": {
+          "doc_count": 0
+        },
+        "<b>St. Gallen</b>: St. Gallen": {
+          "doc_count": 0
+        },
+        "<b>Touraine</b>: Accensement d'une vigne de Marmoutier": {
+          "doc_count": 0
+        },
+        "<b>Touraine</b>: Accord entre Bonneval et Marmoutier": {
+          "doc_count": 0
+        },
+        "<b>Touraine</b>: Cormery (TELMA)": {
+          "doc_count": 0
+        },
+        "<b>Touraine</b>: Eudes": {
+          "doc_count": 0
+        },
+        "<b>Touraine</b>: Fragments de Saint-Julien de Tours": {
+          "doc_count": 0
+        },
+        "<b>Touraine</b>: Marmoutier (TELMA)": {
+          "doc_count": 0
+        },
+        "<b>Touraine</b>: Marmoutier - Dunois": {
+          "doc_count": 0
+        },
+        "<b>Touraine</b>: Marmoutier - Fougères": {
+          "doc_count": 0
+        },
+        "<b>Touraine</b>: Marmoutier - Manceau": {
+          "doc_count": 0
+        },
+        "<b>Touraine</b>: Marmoutier - Pour le perche": {
+          "doc_count": 0
+        },
+        "<b>Touraine</b>: Marmoutier - Serfs": {
+          "doc_count": 0
+        },
+        "<b>Touraine</b>: Marmoutier - Trois actes faux ou interpolés": {
+          "doc_count": 0
+        },
+        "<b>Touraine</b>: Marmoutier - Vendômois": {
+          "doc_count": 0
+        },
+        "<b>Touraine</b>: Marmoutier - Vendômois, Appendix": {
+          "doc_count": 0
+        },
+        "<b>Touraine</b>: Marmoutier Cartulaire blésois": {
+          "doc_count": 0
+        },
+        "<b>Touraine</b>: Saint-Martin de Tours (TELMA)": {
+          "doc_count": 0
+        },
+        "<b>Touraine</b>: Un acte faux de Marmoutier": {
+          "doc_count": 0
+        },
+        "<b>Touraine</b>: Une nouvelle charte de Théotolon": {
+          "doc_count": 0
+        },
+        "<b>Werden</b>: Werden": {
+          "doc_count": 0
+        },
+        "<b>Wissembourg</b>: Weißenburg": {
+          "doc_count": 0
+        },
+        "<b>Zürich</b>: Zürich": {
+          "doc_count": 0
+        }
+      }
+    },
+    "range": {
+      "buckets": [
+        {
+          "key": "<499",
+          "from": -62104060800000.0,
+          "from_as_string": "0002",
+          "to": -46420214400000.0,
+          "to_as_string": "0499",
+          "doc_count": 0
+        },
+        {
+          "key": "500-599",
+          "from": -46388678400000.0,
+          "from_as_string": "0500",
+          "to": -43264540800000.0,
+          "to_as_string": "0599",
+          "doc_count": 0
+        },
+        {
+          "key": "600-699",
+          "from": -43233004800000.0,
+          "from_as_string": "0600",
+          "to": -40108867200000.0,
+          "to_as_string": "0699",
+          "doc_count": 0
+        },
+        {
+          "key": "700-799",
+          "from": -40077331200000.0,
+          "from_as_string": "0700",
+          "to": -36953193600000.0,
+          "to_as_string": "0799",
+          "doc_count": 0
+        },
+        {
+          "key": "800-899",
+          "from": -36921657600000.0,
+          "from_as_string": "0800",
+          "to": -33797433600000.0,
+          "to_as_string": "0899",
+          "doc_count": 0
+        },
+        {
+          "key": "900-999",
+          "from": -33765897600000.0,
+          "from_as_string": "0900",
+          "to": -30641760000000.0,
+          "to_as_string": "0999",
+          "doc_count": 0
+        },
+        {
+          "key": ">1000",
+          "from": -30610224000000.0,
+          "from_as_string": "1000",
+          "doc_count": 0
+        }
+      ]
+    },
+    "no_date": {
+      "doc_count": 4
+    }
+  }
+}

--- a/tests/test_data/advanced_search/__mocks__/_search/elexicon&autocomplete&abba&0&False&0&0&0&0&0&0&0&0&0&0&0&y&&urn&&&regest&&&include&False&&advanced_ids.json
+++ b/tests/test_data/advanced_search/__mocks__/_search/elexicon&autocomplete&abba&0&False&0&0&0&0&0&0&0&0&0&0&0&y&&urn&&&regest&&&include&False&&advanced_ids.json
@@ -1,0 +1,14 @@
+[
+  {
+    "id": "urn:cts:formulae:elexicon.abbas.deu001"
+  },
+  {
+    "id": "urn:cts:formulae:elexicon.abbatissa.deu001"
+  },
+  {
+    "id": "urn:cts:formulae:elexicon.praepositus.deu001"
+  },
+  {
+    "id": "urn:cts:formulae:elexicon.vir_venerabilis.deu001"
+  }
+]

--- a/tests/test_data/advanced_search/__mocks__/_search/elexicon&autocomplete&abba&0&False&0&0&0&0&0&0&0&0&0&0&0&y&&urn&&&regest&&&include&False&&advanced_req.json
+++ b/tests/test_data/advanced_search/__mocks__/_search/elexicon&autocomplete&abba&0&False&0&0&0&0&0&0&0&0&0&0&0&y&&urn&&&regest&&&include&False&&advanced_req.json
@@ -1,0 +1,34 @@
+{
+  "query": {
+    "bool": {
+      "must": [
+        {
+          "match": {
+            "autocomplete": {
+              "query": "abba",
+              "fuzziness": "0"
+            }
+          }
+        }
+      ]
+    }
+  },
+  "sort": [
+    "sort_prefix",
+    "urn"
+  ],
+  "from": 0,
+  "size": 10000,
+  "highlight": {
+    "fields": {
+      "autocomplete": {}
+    },
+    "pre_tags": [
+      "</small><strong>"
+    ],
+    "post_tags": [
+      "</strong><small>"
+    ],
+    "encoder": "html"
+  }
+}

--- a/tests/test_data/advanced_search/__mocks__/_search/elexicon&autocomplete&abba&0&False&0&0&0&0&0&0&0&0&0&0&0&y&&urn&&&regest&&&include&False&&advanced_resp.json
+++ b/tests/test_data/advanced_search/__mocks__/_search/elexicon&autocomplete&abba&0&False&0&0&0&0&0&0&0&0&0&0&0&y&&urn&&&regest&&&include&False&&advanced_resp.json
@@ -1,0 +1,151 @@
+{
+  "took": 2,
+  "timed_out": false,
+  "_shards": {
+    "total": 1,
+    "successful": 1,
+    "skipped": 0,
+    "failed": 0
+  },
+  "hits": {
+    "total": {
+      "value": 4,
+      "relation": "eq"
+    },
+    "max_score": null,
+    "hits": [
+      {
+        "_index": "elexicon_v2",
+        "_type": "_doc",
+        "_id": "urn:cts:formulae:elexicon.abbas.deu001",
+        "_score": null,
+        "_source": {
+          "text": "Abbas, abbatissa Abt, Äbtissin. Aus dem aramäischen abba für Vater, Mönch. Vermutlich bereits in apostolischer Zeit für hervorragende Mitglieder der christlichen Gemeinde gebraucht, wurde abbas im ägyptischen Mönchtum im 4. Jahrhundert zur Bezeichnung für jene Mönche, die Dank ihrer Lebenserfahrung und Tugend als spirituelle Vorbilder und Lehrer dienen konnten. Ohne diese alte Bedeutung vollends zu verlieren, verbreitete sich abbas seit dem 5. Jahrhundert im lateinischen Westen im Rahmen der Organisation des monastischen Lebens als Amtsbezeichnung. Abbates finden sich dabei nicht nur als Klostervorsteher, sondern auch als Stellvertreter von Bischöfen, Leiter von Basiliken mit Märtyrergräbern nebst den dazu gehörenden Klerikergemeinden und auch anderen Kirchen. Maßgeblich für die Entwicklung des Klosterabbatiats wurde die Mönchsregel Benedikts von Nursia († 547). Aufbauend auf früheren Regeln erscheint der Abt bei ihm als Stellvertreter Christi und Vater der Mönche, über welche er nahezu ohne Einschränkungen und Vorbehalt Gewalt ausübt. Scheint der Abt vor Benedikt häufig selbst seinen Nachfolger designiert zu haben, legte die Benediktsregel die (ebenfalls bereits bekannte) Wahl durch die Mönchsgemeinde fest. Zwar finden sich in der Folge wiederholt Bestätigungen des Wahlrechtes, doch wurden zugleich die Rechte der Klostergründer und -eigner wie auch der Bischöfe, den Abt eines Klosters zu ernennen, gestärkt. Von der Merowinger- zur Karolingerzeit wandelt sich die Konzeption von Kloster und Abbatiat. Die Wahrnehmung des materiellen Wertes der Klöster trat verstärkt neben die seiner religiösen Ziele. Äbte wurden nun dem hohen Klerus zugerechnet, entwickelten sich zu eigenen Herrschaftsträgern und fanden sich verstärkt im Umfeld der Könige, die nun auch selbst Äbte einsetzten. Mit diesem Wandel einher ging die Ausweitung der Übernahme von Abbatiaten durch Laien, Kleriker, Kanoniker und Bischöfe und damit die Loslösung des Abtsamtes vom inneren Leben des Klosters. Eine Umkehr dieser Entwicklung begann schließlich mit den Reformbewegungen des 10. Jahrhunderts. HL",
+          "lemmas": null,
+          "regest": null,
+          "title": "Abbas, abbatissa",
+          "urn": "urn:cts:formulae:elexicon.abbas.deu001",
+          "date_string": " ",
+          "comp_ort": " ",
+          "autocomplete": "Abbas, abbatissa Abt, Äbtissin. Aus dem aramäischen abba für Vater, Mönch. Vermutlich bereits in apostolischer Zeit für hervorragende Mitglieder der christlichen Gemeinde gebraucht, wurde abbas im ägyptischen Mönchtum im 4. Jahrhundert zur Bezeichnung für jene Mönche, die Dank ihrer Lebenserfahrung und Tugend als spirituelle Vorbilder und Lehrer dienen konnten. Ohne diese alte Bedeutung vollends zu verlieren, verbreitete sich abbas seit dem 5. Jahrhundert im lateinischen Westen im Rahmen der Organisation des monastischen Lebens als Amtsbezeichnung. Abbates finden sich dabei nicht nur als Klostervorsteher, sondern auch als Stellvertreter von Bischöfen, Leiter von Basiliken mit Märtyrergräbern nebst den dazu gehörenden Klerikergemeinden und auch anderen Kirchen. Maßgeblich für die Entwicklung des Klosterabbatiats wurde die Mönchsregel Benedikts von Nursia († 547). Aufbauend auf früheren Regeln erscheint der Abt bei ihm als Stellvertreter Christi und Vater der Mönche, über welche er nahezu ohne Einschränkungen und Vorbehalt Gewalt ausübt. Scheint der Abt vor Benedikt häufig selbst seinen Nachfolger designiert zu haben, legte die Benediktsregel die (ebenfalls bereits bekannte) Wahl durch die Mönchsgemeinde fest. Zwar finden sich in der Folge wiederholt Bestätigungen des Wahlrechtes, doch wurden zugleich die Rechte der Klostergründer und -eigner wie auch der Bischöfe, den Abt eines Klosters zu ernennen, gestärkt. Von der Merowinger- zur Karolingerzeit wandelt sich die Konzeption von Kloster und Abbatiat. Die Wahrnehmung des materiellen Wertes der Klöster trat verstärkt neben die seiner religiösen Ziele. Äbte wurden nun dem hohen Klerus zugerechnet, entwickelten sich zu eigenen Herrschaftsträgern und fanden sich verstärkt im Umfeld der Könige, die nun auch selbst Äbte einsetzten. Mit diesem Wandel einher ging die Ausweitung der Übernahme von Abbatiaten durch Laien, Kleriker, Kanoniker und Bischöfe und damit die Loslösung des Abtsamtes vom inneren Leben des Klosters. Eine Umkehr dieser Entwicklung begann schließlich mit den Reformbewegungen des 10. Jahrhunderts. HL",
+          "autocomplete_lemmas": null,
+          "autocomplete_regest": null,
+          "orig_comp_ort": " ",
+          "collection": "elexicon",
+          "forgery": false,
+          "sort_prefix": 1
+        },
+        "highlight": {
+          "autocomplete": [
+            "</small><strong>Abbas</strong><small>, </small><strong>abbatissa</strong><small> Abt, Äbtissin. Aus dem aramäischen </small><strong>abba</strong><small> für Vater, Mönch.",
+            "bereits in apostolischer Zeit für hervorragende Mitglieder der christlichen Gemeinde gebraucht, wurde </small><strong>abbas</strong><small>",
+            "Ohne diese alte Bedeutung vollends zu verlieren, verbreitete sich </small><strong>abbas</strong><small> seit dem 5.",
+            "</small><strong>Abbates</strong><small> finden sich dabei nicht nur als Klostervorsteher, sondern auch als Stellvertreter von Bischöfen",
+            "Von der Merowinger- zur Karolingerzeit wandelt sich die Konzeption von Kloster und </small><strong>Abbatiat</strong><small>."
+          ]
+        },
+        "sort": [
+          1,
+          "urn:cts:formulae:elexicon.abbas.deu001"
+        ]
+      },
+      {
+        "_index": "elexicon_v2",
+        "_type": "_doc",
+        "_id": "urn:cts:formulae:elexicon.abbatissa.deu001",
+        "_score": null,
+        "_source": {
+          "text": "Abbas, abbatissa Abt, Äbtissin. Aus dem aramäischen abba für Vater, Mönch. Vermutlich bereits in apostolischer Zeit für hervorragende Mitglieder der christlichen Gemeinde gebraucht, wurde abbas im ägyptischen Mönchtum im 4. Jahrhundert zur Bezeichnung für jene Mönche, die Dank ihrer Lebenserfahrung und Tugend als spirituelle Vorbilder und Lehrer dienen konnten. Ohne diese alte Bedeutung vollends zu verlieren, verbreitete sich abbas seit dem 5. Jahrhundert im lateinischen Westen im Rahmen der Organisation des monastischen Lebens als Amtsbezeichnung. Abbates finden sich dabei nicht nur als Klostervorsteher, sondern auch als Stellvertreter von Bischöfen, Leiter von Basiliken mit Märtyrergräbern nebst den dazu gehörenden Klerikergemeinden und auch anderen Kirchen. Maßgeblich für die Entwicklung des Klosterabbatiats wurde die Mönchsregel Benedikts von Nursia († 547). Aufbauend auf früheren Regeln erscheint der Abt bei ihm als Stellvertreter Christi und Vater der Mönche, über welche er nahezu ohne Einschränkungen und Vorbehalt Gewalt ausübt. Scheint der Abt vor Benedikt häufig selbst seinen Nachfolger designiert zu haben, legte die Benediktsregel die (ebenfalls bereits bekannte) Wahl durch die Mönchsgemeinde fest. Zwar finden sich in der Folge wiederholt Bestätigungen des Wahlrechtes, doch wurden zugleich die Rechte der Klostergründer und -eigner wie auch der Bischöfe, den Abt eines Klosters zu ernennen, gestärkt. Von der Merowinger- zur Karolingerzeit wandelt sich die Konzeption von Kloster und Abbatiat. Die Wahrnehmung des materiellen Wertes der Klöster trat verstärkt neben die seiner religiösen Ziele. Äbte wurden nun dem hohen Klerus zugerechnet, entwickelten sich zu eigenen Herrschaftsträgern und fanden sich verstärkt im Umfeld der Könige, die nun auch selbst Äbte einsetzten. Mit diesem Wandel einher ging die Ausweitung der Übernahme von Abbatiaten durch Laien, Kleriker, Kanoniker und Bischöfe und damit die Loslösung des Abtsamtes vom inneren Leben des Klosters. Eine Umkehr dieser Entwicklung begann schließlich mit den Reformbewegungen des 10. Jahrhunderts. HL",
+          "lemmas": null,
+          "regest": null,
+          "title": "Abbas, abbatissa",
+          "urn": "urn:cts:formulae:elexicon.abbatissa.deu001",
+          "date_string": " ",
+          "comp_ort": " ",
+          "autocomplete": "Abbas, abbatissa Abt, Äbtissin. Aus dem aramäischen abba für Vater, Mönch. Vermutlich bereits in apostolischer Zeit für hervorragende Mitglieder der christlichen Gemeinde gebraucht, wurde abbas im ägyptischen Mönchtum im 4. Jahrhundert zur Bezeichnung für jene Mönche, die Dank ihrer Lebenserfahrung und Tugend als spirituelle Vorbilder und Lehrer dienen konnten. Ohne diese alte Bedeutung vollends zu verlieren, verbreitete sich abbas seit dem 5. Jahrhundert im lateinischen Westen im Rahmen der Organisation des monastischen Lebens als Amtsbezeichnung. Abbates finden sich dabei nicht nur als Klostervorsteher, sondern auch als Stellvertreter von Bischöfen, Leiter von Basiliken mit Märtyrergräbern nebst den dazu gehörenden Klerikergemeinden und auch anderen Kirchen. Maßgeblich für die Entwicklung des Klosterabbatiats wurde die Mönchsregel Benedikts von Nursia († 547). Aufbauend auf früheren Regeln erscheint der Abt bei ihm als Stellvertreter Christi und Vater der Mönche, über welche er nahezu ohne Einschränkungen und Vorbehalt Gewalt ausübt. Scheint der Abt vor Benedikt häufig selbst seinen Nachfolger designiert zu haben, legte die Benediktsregel die (ebenfalls bereits bekannte) Wahl durch die Mönchsgemeinde fest. Zwar finden sich in der Folge wiederholt Bestätigungen des Wahlrechtes, doch wurden zugleich die Rechte der Klostergründer und -eigner wie auch der Bischöfe, den Abt eines Klosters zu ernennen, gestärkt. Von der Merowinger- zur Karolingerzeit wandelt sich die Konzeption von Kloster und Abbatiat. Die Wahrnehmung des materiellen Wertes der Klöster trat verstärkt neben die seiner religiösen Ziele. Äbte wurden nun dem hohen Klerus zugerechnet, entwickelten sich zu eigenen Herrschaftsträgern und fanden sich verstärkt im Umfeld der Könige, die nun auch selbst Äbte einsetzten. Mit diesem Wandel einher ging die Ausweitung der Übernahme von Abbatiaten durch Laien, Kleriker, Kanoniker und Bischöfe und damit die Loslösung des Abtsamtes vom inneren Leben des Klosters. Eine Umkehr dieser Entwicklung begann schließlich mit den Reformbewegungen des 10. Jahrhunderts. HL",
+          "autocomplete_lemmas": null,
+          "autocomplete_regest": null,
+          "orig_comp_ort": " ",
+          "collection": "elexicon",
+          "forgery": false,
+          "sort_prefix": 1
+        },
+        "highlight": {
+          "autocomplete": [
+            "</small><strong>Abbas</strong><small>, </small><strong>abbatissa</strong><small> Abt, Äbtissin. Aus dem aramäischen </small><strong>abba</strong><small> für Vater, Mönch.",
+            "bereits in apostolischer Zeit für hervorragende Mitglieder der christlichen Gemeinde gebraucht, wurde </small><strong>abbas</strong><small>",
+            "Ohne diese alte Bedeutung vollends zu verlieren, verbreitete sich </small><strong>abbas</strong><small> seit dem 5.",
+            "</small><strong>Abbates</strong><small> finden sich dabei nicht nur als Klostervorsteher, sondern auch als Stellvertreter von Bischöfen",
+            "Von der Merowinger- zur Karolingerzeit wandelt sich die Konzeption von Kloster und </small><strong>Abbatiat</strong><small>."
+          ]
+        },
+        "sort": [
+          1,
+          "urn:cts:formulae:elexicon.abbatissa.deu001"
+        ]
+      },
+      {
+        "_index": "elexicon_v2",
+        "_type": "_doc",
+        "_id": "urn:cts:formulae:elexicon.praepositus.deu001",
+        "_score": null,
+        "_source": {
+          "text": "Praepositus Vorsteher, Oberer, Erster einer Gruppe oder Vorgesetzter; im 4. -5. Jahrhundert auch synonym zu decanus gebraucht. In der Antike Bezeichnung für verschiedene öffentliche Amtsträger mit leitenden Funktionen. Im frühen Mönchtum hatte der praepositus zunächst, gemeinsam mit dem für geistlichen Belange verantwortlichen presbyter eine leitende Funktion, übte die Aufsicht aus und übernahm verschiedene Verantwortungen. Seit dem 6. Jahrhundert trat der praepositus hinter den abbas zurück, wurde dessen Stellvertreter und fand in der Verwaltung der Klostergüter eine seiner Hauptaufgaben. Im weltlichen Bereich findet sich praepositus im frühen Mittelalter als Bezeichnung für Vertreter von Herrschaftsträgern. Als solche konnten sie Funktionen in Rechtsprechung und Administration übernehmen oder auch Grundbesitz verwalten. Damit verbunden konnten die praepositi in zunehmendem Maße auch Herrschaftsrechte wie Abgabenerhebung, Rechtsfindung und Rechtsverfolgung ausüben. HL",
+          "lemmas": null,
+          "regest": null,
+          "title": "Praepositus",
+          "urn": "urn:cts:formulae:elexicon.praepositus.deu001",
+          "date_string": " ",
+          "comp_ort": " ",
+          "autocomplete": "Praepositus Vorsteher, Oberer, Erster einer Gruppe oder Vorgesetzter; im 4. -5. Jahrhundert auch synonym zu decanus gebraucht. In der Antike Bezeichnung für verschiedene öffentliche Amtsträger mit leitenden Funktionen. Im frühen Mönchtum hatte der praepositus zunächst, gemeinsam mit dem für geistlichen Belange verantwortlichen presbyter eine leitende Funktion, übte die Aufsicht aus und übernahm verschiedene Verantwortungen. Seit dem 6. Jahrhundert trat der praepositus hinter den abbas zurück, wurde dessen Stellvertreter und fand in der Verwaltung der Klostergüter eine seiner Hauptaufgaben. Im weltlichen Bereich findet sich praepositus im frühen Mittelalter als Bezeichnung für Vertreter von Herrschaftsträgern. Als solche konnten sie Funktionen in Rechtsprechung und Administration übernehmen oder auch Grundbesitz verwalten. Damit verbunden konnten die praepositi in zunehmendem Maße auch Herrschaftsrechte wie Abgabenerhebung, Rechtsfindung und Rechtsverfolgung ausüben. HL",
+          "autocomplete_lemmas": null,
+          "autocomplete_regest": null,
+          "orig_comp_ort": " ",
+          "collection": "elexicon",
+          "forgery": false,
+          "sort_prefix": 1
+        },
+        "highlight": {
+          "autocomplete": [
+            "Jahrhundert trat der praepositus hinter den </small><strong>abbas</strong><small> zurück, wurde dessen Stellvertreter und fand in der"
+          ]
+        },
+        "sort": [
+          1,
+          "urn:cts:formulae:elexicon.praepositus.deu001"
+        ]
+      },
+      {
+        "_index": "elexicon_v2",
+        "_type": "_doc",
+        "_id": "urn:cts:formulae:elexicon.vir_venerabilis.deu001",
+        "_score": null,
+        "_source": {
+          "text": "Vir venerabilis: wörtlich „ehrwürdiger Mann“. Seit der Spätantike war der Ehrentitel des vir venerabilis in erster Linie Bischöfen vorbehalten Spätestens seit dem Ende des 6. Jahrhunderts erhielten auch Äbte diese Titulatur In den merowingischen Königsurkunden zeigt sich die Tendenz nur den Abt auf diese Weise zu bezeichnen, während der Bischof in der Regel mit dem Ehrentitel vir apostolicus versehen wird. In wenigen Ausnahmefällen werden auch Diakone oder Kleriker als viri venerabiles bezeichnet jedoch stehen die jeweiligen Personen, sofern dies nachzuvollziehen ist, stets in Verbindung zu Abbatiat oder Bischofsamt In der Folgezeit scheint sich die Verwendung der Titulatur für Äbte und Bischöfe durchgesetzt zu haben Die Verwendung des adjektivischen Epithetons venerabilis das seit der Spätantike ähnlich wie sanctus „heilig“) als Ausdruck der Ehrerweisung für Geistliche jeden Ranges und auch für Weltliche (z. B. für den Kaiser) gebraucht wurde, ist von dieser Titulatur abzugrenzen In der zweiten Hälfte des 9. Jahrhunderts wird der Gebrauch des Zusatzes vir aufgegeben AM",
+          "lemmas": null,
+          "regest": null,
+          "title": "Vir venerabilis:",
+          "urn": "urn:cts:formulae:elexicon.vir_venerabilis.deu001",
+          "date_string": " ",
+          "comp_ort": " ",
+          "autocomplete": "Vir venerabilis: wörtlich „ehrwürdiger Mann“. Seit der Spätantike war der Ehrentitel des vir venerabilis in erster Linie Bischöfen vorbehalten Spätestens seit dem Ende des 6. Jahrhunderts erhielten auch Äbte diese Titulatur In den merowingischen Königsurkunden zeigt sich die Tendenz nur den Abt auf diese Weise zu bezeichnen, während der Bischof in der Regel mit dem Ehrentitel vir apostolicus versehen wird. In wenigen Ausnahmefällen werden auch Diakone oder Kleriker als viri venerabiles bezeichnet jedoch stehen die jeweiligen Personen, sofern dies nachzuvollziehen ist, stets in Verbindung zu Abbatiat oder Bischofsamt In der Folgezeit scheint sich die Verwendung der Titulatur für Äbte und Bischöfe durchgesetzt zu haben Die Verwendung des adjektivischen Epithetons venerabilis das seit der Spätantike ähnlich wie sanctus „heilig“) als Ausdruck der Ehrerweisung für Geistliche jeden Ranges und auch für Weltliche (z. B. für den Kaiser) gebraucht wurde, ist von dieser Titulatur abzugrenzen In der zweiten Hälfte des 9. Jahrhunderts wird der Gebrauch des Zusatzes vir aufgegeben AM",
+          "autocomplete_lemmas": null,
+          "autocomplete_regest": null,
+          "orig_comp_ort": " ",
+          "collection": "elexicon",
+          "forgery": false,
+          "sort_prefix": 1
+        },
+        "highlight": {
+          "autocomplete": [
+            "bezeichnet jedoch stehen die jeweiligen Personen, sofern dies nachzuvollziehen ist, stets in Verbindung zu </small><strong>Abbatiat</strong><small>"
+          ]
+        },
+        "sort": [
+          1,
+          "urn:cts:formulae:elexicon.vir_venerabilis.deu001"
+        ]
+      }
+    ]
+  }
+}

--- a/tests/test_data/advanced_search/__mocks__/_search/formulae+chartae&False&pippin*+dux&0&False&0&0&0&0&0&0&0&0&0&0&0&False&&urn&&pippin*+dux&regest&&&include&False&&simple_resp.json
+++ b/tests/test_data/advanced_search/__mocks__/_search/formulae+chartae&False&pippin*+dux&0&False&0&0&0&0&0&0&0&0&0&0&0&False&&urn&&pippin*+dux&regest&&&include&False&&simple_resp.json
@@ -1,5 +1,5 @@
 {
-  "took": 14,
+  "took": 13,
   "timed_out": false,
   "_shards": {
     "total": 56,

--- a/tests/test_data/advanced_search/__mocks__/_search/merowinger1&False&&0&False&0&0&0&0&0&0&0&0&0&0&0&False&&urn&&&regest&&&only&False&&advanced_resp.json
+++ b/tests/test_data/advanced_search/__mocks__/_search/merowinger1&False&&0&False&0&0&0&0&0&0&0&0&0&0&0&False&&urn&&&regest&&&only&False&&advanced_resp.json
@@ -1,5 +1,5 @@
 {
-  "took": 17,
+  "took": 16,
   "timed_out": false,
   "_shards": {
     "total": 1,

--- a/tests/test_data/advanced_search/__mocks__/_search/mondsee&False&&0&False&0&0&0&0&0&0&0&0&0&0&0&False&&urn&&&regest&Poenformel+Stipulationsformel&&include&False&&advanced_resp.json
+++ b/tests/test_data/advanced_search/__mocks__/_search/mondsee&False&&0&False&0&0&0&0&0&0&0&0&0&0&0&False&&urn&&&regest&Poenformel+Stipulationsformel&&include&False&&advanced_resp.json
@@ -1,5 +1,5 @@
 {
-  "took": 6,
+  "took": 7,
   "timed_out": false,
   "_shards": {
     "total": 1,

--- a/tests/test_data/advanced_search/__mocks__/_search/mondsee&False&christ*+vener?bili&0&False&0&0&0&0&0&0&0&0&0&0&0&False&&urn&&&regest&Narratio&&include&False&&advanced_resp.json
+++ b/tests/test_data/advanced_search/__mocks__/_search/mondsee&False&christ*+vener?bili&0&False&0&0&0&0&0&0&0&0&0&0&0&False&&urn&&&regest&Narratio&&include&False&&advanced_resp.json
@@ -1,5 +1,5 @@
 {
-  "took": 3,
+  "took": 1,
   "timed_out": false,
   "_shards": {
     "total": 1,

--- a/tests/test_data/advanced_search/__mocks__/_search/mondsee&False&cwhr[ij]sjt[uvw]iu&0&False&0&0&0&0&0&0&0&0&0&0&0&False&&urn&&&regest&Narratio&personenname&include&True&&advanced_resp.json
+++ b/tests/test_data/advanced_search/__mocks__/_search/mondsee&False&cwhr[ij]sjt[uvw]iu&0&False&0&0&0&0&0&0&0&0&0&0&0&False&&urn&&&regest&Narratio&personenname&include&True&&advanced_resp.json
@@ -1,5 +1,5 @@
 {
-  "took": 2,
+  "took": 1,
   "timed_out": false,
   "_shards": {
     "total": 1,

--- a/tests/test_data/advanced_search/__mocks__/_search/mondsee&False&in+loco+qui+nuncupatur&AUTO&False&0&0&0&0&0&0&0&0&0&0&0&False&&urn&&&regest&&&include&False&&advanced_resp.json
+++ b/tests/test_data/advanced_search/__mocks__/_search/mondsee&False&in+loco+qui+nuncupatur&AUTO&False&0&0&0&0&0&0&0&0&0&0&0&False&&urn&&&regest&&&include&False&&advanced_resp.json
@@ -1,5 +1,5 @@
 {
-  "took": 3,
+  "took": 5,
   "timed_out": false,
   "_shards": {
     "total": 1,

--- a/tests/test_data/advanced_search/__mocks__/_search/mondsee&False&in+loco+qui+nuncupatur&AUTO&False&0&0&0&0&0&0&0&0&0&0&0&False&&urn&&&regest&Narratio&&include&False&&advanced_resp.json
+++ b/tests/test_data/advanced_search/__mocks__/_search/mondsee&False&in+loco+qui+nuncupatur&AUTO&False&0&0&0&0&0&0&0&0&0&0&0&False&&urn&&&regest&Narratio&&include&False&&advanced_resp.json
@@ -1,5 +1,5 @@
 {
-  "took": 3,
+  "took": 2,
   "timed_out": false,
   "_shards": {
     "total": 1,

--- a/tests/test_data/advanced_search/__mocks__/_search/mondsee&False&temp?re&0&False&0&0&0&0&0&0&0&0&0&0&0&False&&urn&&&regest&Stipulationsformel&&include&False&&advanced_resp.json
+++ b/tests/test_data/advanced_search/__mocks__/_search/mondsee&False&temp?re&0&False&0&0&0&0&0&0&0&0&0&0&0&False&&urn&&&regest&Stipulationsformel&&include&False&&advanced_resp.json
@@ -1,5 +1,5 @@
 {
-  "took": 13,
+  "took": 7,
   "timed_out": false,
   "_shards": {
     "total": 1,

--- a/tests/test_data/advanced_search/__mocks__/_search/mondsee&False&tempore&0&False&0&0&0&0&0&0&0&0&0&0&0&False&&urn&&&regest&Stipulationsformel&&include&False&&advanced_resp.json
+++ b/tests/test_data/advanced_search/__mocks__/_search/mondsee&False&tempore&0&False&0&0&0&0&0&0&0&0&0&0&0&False&&urn&&&regest&Stipulationsformel&&include&False&&advanced_resp.json
@@ -1,5 +1,5 @@
 {
-  "took": 13,
+  "took": 10,
   "timed_out": false,
   "_shards": {
     "total": 1,


### PR DESCRIPTION
- Enabled searching through the elexicon on the elexicon corpus page
- When elexicon is selected as a corpus, the lemma checkbox on the simple search is disabled
- Implemented search-as-you-type completion for simple and advanced elexicon searches
- Added search button to the bottom of the advanced search page