### PR TITLE
Nav letters now on Bibliography 

### DIFF
--- a/assets/css/theme.css
+++ b/assets/css/theme.css
@@ -771,6 +771,11 @@ p.flash-grey {
     animation-duration: 4s;
 }
 
+li.flash-grey {
+    animation-name: text-focus;
+    animation-duration: 2s;
+}
+
 .paragraph-link {
     font-size: 50%;
     top: -.5em;

--- a/assets/js/empty.js
+++ b/assets/js/empty.js
@@ -613,4 +613,29 @@ $(document).ready(function () {
             }, 4000);
         });
     })
+    
+    $('.corpus-nrs').click(function() {
+        var t = $(this).attr('href');
+        var navbarHeight = $('#mainNavbar').height();
+        var bodyHeight = $('body').height();
+        if ( $(t).offset().top > bodyHeight ) {
+            $('html, body').animate( {
+                scrollTop: $(t).offset().top - 25 
+            }, 500, function() {
+                $(t).addClass('flash-grey')
+                setTimeout(function() {
+                    $(t).removeClass('flash-grey');
+                }, 2000);
+            });
+        } else {
+            $('html, body').animate( {
+                scrollTop: $(t).offset().top - navbarHeight - 25
+            }, 500, function() {
+                $(t).addClass('flash-grey')
+                setTimeout(function() {
+                    $(t).removeClass('flash-grey');
+                }, 2000);
+            });
+        }
+    })
 })

--- a/assets/js/empty.js
+++ b/assets/js/empty.js
@@ -596,10 +596,21 @@ $(document).ready(function () {
         }
     });
     
-    $(window).scroll(function(){
+    $('.bibl-letter,.elex-letter').click(function() {
+        var t = $(this).attr('href');
         var navbarHeight = $('#mainNavbar').height();
-        var letterPos = $('#elex-letters').offset();
-        var bodyHeight = $('body').height();
-        $('#elex-letters').css('top', Math.min(Math.max(bodyHeight + navbarHeight - letterPos.top, 0), navbarHeight + 20));
-    });
+        var letterPos = $('#elex-letters').height();
+        var targetOffset = letterPos + 25;
+        if ( t.includes('-A') || t.includes('-nr') ) {
+            targetOffset += navbarHeight;
+        }
+        $('html, body').animate({
+            scrollTop: $(t).offset().top - targetOffset
+        }, 500, function() {
+            $(t).addClass('flash-grey')
+            setTimeout(function() {
+                $(t).removeClass('flash-grey');
+            }, 4000);
+        });
+    })
 })

--- a/templates/main/bibliography.html
+++ b/templates/main/bibliography.html
@@ -5,14 +5,100 @@
    <header>
       <h1 class="text-center">{{ _('Bibliographie') }}</h1>
    </header>
+   <h4 class="text-center">{{ _('Gehe zu Buchstabe:') }}</h4>
+   <div class="row" id="elex-letters">
+      <div class="col text-center">
+         <a type="button"
+            class="elex-letter btn px-1 mx-0 btn-outline-primary"
+            href="#BL-nr">#</a>
+         <a type="button"
+            class="elex-letter btn px-1 mx-0 btn-outline-primary"
+            href="#BL-A">A</a>
+         <a type="button"
+            class="elex-letter btn px-1 mx-0 btn-outline-primary"
+            href="#BL-B">B</a>
+         <a type="button"
+            class="elex-letter btn px-1 mx-0 btn-outline-primary"
+            href="#BL-C">C</a>
+         <a type="button"
+            class="elex-letter btn px-1 mx-0 btn-outline-primary"
+            href="#BL-D">D</a>
+         <a type="button"
+            class="elex-letter btn px-1 mx-0 btn-outline-primary"
+            href="#BL-E">E</a>
+         <a type="button"
+            class="elex-letter btn px-1 mx-0 btn-outline-primary"
+            href="#BL-F">F</a>
+         <a type="button"
+            class="elex-letter btn px-1 mx-0 btn-outline-primary"
+            href="#BL-G">G</a>
+         <a type="button"
+            class="elex-letter btn px-1 mx-0 btn-outline-primary"
+            href="#BL-H">H</a>
+         <a type="button"
+            class="elex-letter btn px-1 mx-0 btn-outline-primary"
+            href="#BL-I">I</a>
+         <a type="button"
+            class="elex-letter btn px-1 mx-0 btn-outline-primary"
+            href="#BL-J">J</a>
+         <a type="button"
+            class="elex-letter btn px-1 mx-0 btn-outline-primary"
+            href="#BL-K">K</a>
+         <a type="button"
+            class="elex-letter btn px-1 mx-0 btn-outline-primary"
+            href="#BL-L">L</a>
+         <a type="button"
+            class="elex-letter btn px-1 mx-0 btn-outline-primary"
+            href="#BL-M">M</a>
+         <a type="button"
+            class="elex-letter btn px-1 mx-0 btn-outline-primary"
+            href="#BL-N">N</a>
+         <a type="button"
+            class="elex-letter btn px-1 mx-0 btn-outline-primary"
+            href="#BL-O">O</a>
+         <a type="button"
+            class="elex-letter btn px-1 mx-0 btn-outline-primary"
+            href="#BL-P">P</a>
+         <a type="button"
+            class="elex-letter btn px-1 mx-0 btn-outline-secondary disabled"
+            href="#BL-Q">Q</a>
+         <a type="button"
+            class="elex-letter btn px-1 mx-0 btn-outline-primary"
+            href="#BL-R">R</a>
+         <a type="button"
+            class="elex-letter btn px-1 mx-0 btn-outline-primary"
+            href="#BL-S">S</a>
+         <a type="button"
+            class="elex-letter btn px-1 mx-0 btn-outline-primary"
+            href="#BL-T">T</a>
+         <a type="button"
+            class="elex-letter btn px-1 mx-0 btn-outline-primary"
+            href="#BL-U">U</a>
+         <a type="button"
+            class="elex-letter btn px-1 mx-0 btn-outline-primary"
+            href="#BL-V">V</a>
+         <a type="button"
+            class="elex-letter btn px-1 mx-0 btn-outline-primary"
+            href="#BL-W">W</a>
+         <a type="button"
+            class="elex-letter btn px-1 mx-0 btn-outline-secondary disabled"
+            href="#BL-X">X</a>
+         <a type="button"
+            class="elex-letter btn px-1 mx-0 btn-outline-secondary disabled"
+            href="#BL-Y">Y</a>
+         <a type="button"
+            class="elex-letter btn px-1 mx-0 btn-outline-primary"
+            href="#BL-Z">Z</a>
+      </div>
+   </div>
     
     
         
         
-   <p class="biblEntry">
+   <p class="biblEntry" id="BL-nr">
       <span class="bookTitle">25 Jahre Bundesnotarkammer 1961 bis 1986</span>, <span class="publicationPlace">München</span> 
       <span class="publicationYear">1986</span> (<span class="publicationSeries">Deutsche Notar-Zeitschrift. Sonderheft</span>).</p>
-   <p class="biblEntry">
+   <p class="biblEntry" id="BL-A">
       <span class="surname">Adam</span>, <span class="forename">Hildegard</span>: <span class="bookTitle">Das Zollwesen im fränkischen Reich und das spätkarolingische Wirtschaftsleben. Ein Überblick über Zoll, Handel und Verkehr im 9. Jahrhundert</span>, <span class="publicationPlace">Stuttgart</span> 
       <span class="publicationYear">1996</span> (<span class="publicationSeries">Vierteljahrschrift für Sozial- und Wirtschaftsgeschichte. Beihefte 126</span>).</p>
    <p class="biblEntry">
@@ -149,7 +235,7 @@
       <span class="surname"> Gerhards</span> (Hgg.), <span class="bookTitle">Liturgie und Frauenfrage</span>, <span class="publicationPlace">St. Ottilien</span> 
       <span class="publicationYear">1991</span>, <span class="pubPages">S. 31–65</span>.</p>
    <p class="biblEntry">
-      <span class="surname">Appuhn</span>, <span class="forename">Horst</span>: <span class="sectionTitle">Art. Kathedra</span>, in: <span class="bookTitle">Lexikon des Mittelalters Bd. 5</span>, <span class="publicationYear">1991</span>, <span class="pubPages">S. 1074-1075</span>.</p>
+      <span class="surname">Appuhn</span>, <span class="forename">Horst</span>: <span class="sectionTitle">Art. Kathedra</span>, in: <span class="bookTitle">Lexikon des Mittelalters Bd. 5</span>, <span class="publicationYear">1991</span>, <span class="pubPages">S. S 1074-1075</span>.</p>
    <p class="biblEntry">
       <span class="surname">Ardura</span>, <span class="forename">Bernard</span>: <span class="sectionTitle">Du "Praepositus" de saint Augustin à l'abbé dans la tradition prémontrée jusqu'à la fin de l'Ancien Régime</span>, in: <span class="forename">Dominique-Marie</span> 
       <span class="surname">Dauzet</span> und <span class="forename">Martine</span> 
@@ -187,7 +273,7 @@
       <span class="surname">Auzépy</span>, <span class="forename">Marie-France</span> und <span class="forename">Guillaume</span> 
       <span class="surname"> Saint-Guillain</span>: <span class="bookTitle">Oralité et lien social au Moyen Âge (Occident, Byzance, Islam): parole donnée, foi jurée, serment ; [ce livre rassemble les contributions au Colloque International "Oralité et Lien Social (Occident, Byzance, Islam): Parole Donnée, Foi Jurée, Serment" qui s'est tenu à Paris du 10 au 12 mai 2007]</span>, <span class="publicationPlace">Paris</span> 
       <span class="publicationYear">2008</span>.</p>
-   <p class="biblEntry">
+   <p class="biblEntry" id="BL-B">
       <span class="surname">Babusiaux</span>, <span class="forename">Ulrike</span>, <span class="forename">Peter</span> 
       <span class="surname"> Nobel</span> und <span class="forename">Johannes</span> 
       <span class="surname"> Platschek</span>: <span class="bookTitle">Der Bürge einst und jetzt: Festschrift für Alfons Bürge</span>, <span class="publicationPlace">Zürich</span> 
@@ -729,7 +815,7 @@
       <span class="surname">Büttner</span>, <span class="forename">Jan Ulrich</span>: <span class="sectionTitle">Sünde als Krankheit: Buße als Heilung in den Bußbüchern des frühen Mittelalters</span>, in: <span class="forename">Cordula</span> 
       <span class="surname">Nolte</span> (Hg.), <span class="bookTitle">Homo debilis. Behinderte - Kranke - Versehrte in der Gesellschaft des Mittelalters</span>, <span class="publicationPlace">Korb</span> 
       <span class="publicationYear">2009</span>, <span class="pubPages">S. 57–78</span>.</p>
-   <p class="biblEntry">
+   <p class="biblEntry" id="BL-C">
       <span class="surname">Camby</span>, <span class="forename">Christophe</span>: <span class="bookTitle">Wergeld ou uueregildus: le rachat pécuniaire de l'offense entre continuités romaines et innovation germanique</span>, <span class="publicationPlace">Genève</span> 
       <span class="publicationYear">2013</span> (<span class="publicationSeries">Rayon histoire de la Librairie Droz</span>).</p>
    <p class="biblEntry">
@@ -750,6 +836,9 @@
    <p class="biblEntry">
       <span class="bookTitle">Caratteri del secolo 7 in occidente</span>, <span class="publicationPlace">Spoleto</span> 
       <span class="publicationYear">1958</span>.</p>
+   <p class="biblEntry">
+      <span class="surname">Cárcel Ortí</span>, <span class="forename">María Milagros</span>: <span class="bookTitle">Vocabulaire international de la diplomatique</span>, <span class="publicationPlace">Valéncia</span> 
+      <span class="publicationYear">1994</span> (<span class="publicationSeries">Collecció oberta (Valencia) 28</span>).</p>
    <p class="biblEntry">
       <span class="surname">Cardona</span>, <span class="forename">Giorgio</span>: <span class="sectionTitle">Il nomi della parentela</span>, in: <span class="forename">Piero</span> 
       <span class="surname">Melograni</span> (Hg.), <span class="bookTitle">La famiglia Italiana dall'ottocento a oggi</span>, <span class="publicationPlace">Bari</span> 
@@ -805,14 +894,14 @@
       <span class="surname">Janssen</span> und <span class="forename">Dietrich</span> 
       <span class="surname"> Lohrmann</span> (Hgg.), <span class="bookTitle">Villa, curtis, grangia</span>, <span class="publicationPlace">München u.a.</span> 
       <span class="publicationYear">1983</span>,  (<span class="publicationSeries">Beihefte der Francia</span>), <span class="pubPages">S. 165–184</span>.</p>
+   <p class="biblEntry">
+      <span class="surname">Chénon</span>, <span class="forename">Émile</span>: <span class="bookTitle">Histoire générale du droit français public et privé, des origines à 1815</span>, <span class="publicationPlace">Paris</span> 
+      <span class="publicationYear">1926-1929</span>.</p>
    <p class="biblEntry">: <span class="sectionTitle">Chlotharii II. edictum: 614 Oct 18</span>, in: <span class="bookTitle">Capitularia regum Francorum</span>, <span class="publicationPlace">Hannover</span> 
       <span class="publicationYear">1835</span>,  (<span class="publicationSeries">Monumenta Germaniae Historica. Capitularia regum Francorum</span>), <span class="pubPages">S. 20–23</span>.</p>
    <p class="biblEntry">
       <span class="surname">Churruca</span>, <span class="forename">Juan de</span>: <span class="sectionTitle">Le concept de droit coutumier chez Isidore de Seville</span>, in: <span class="bookTitle">Coutumes et libertés</span>, <span class="publicationPlace">Montpellier</span> 
       <span class="publicationYear">1988</span>, <span class="pubPages">S. 145–154</span>.</p>
-   <p class="biblEntry">
-      <span class="surname">Chénon</span>, <span class="forename">Émile</span>: <span class="bookTitle">Histoire générale du droit français public et privé, des origines à 1815</span>, <span class="publicationPlace">Paris</span> 
-      <span class="publicationYear">1926-1929</span>.</p>
    <p class="biblEntry">
       <span class="surname">Classen</span>, <span class="forename">Peter</span>: <span class="bookTitle">Recht und Schrift im Mittelalter</span>, <span class="publicationPlace">Sigmaringen</span> 
       <span class="publicationYear">1977</span> (<span class="publicationSeries">Vorträge und Forschungen 23</span>).</p>
@@ -841,7 +930,7 @@
       <span class="surname">Claude</span>, <span class="forename">Dietrich</span>: <span class="bookTitle">Der Handel im westlichen Mittelmeer während des Frühmittelalters</span>, <span class="publicationPlace">Göttingen</span> 
       <span class="publicationYear">1985</span> (<span class="publicationSeries">Abhandlungen der Akademie der Wissenschaften in Göttingen. Philologisch-Historische Klasse 144</span>).</p>
    <p class="biblEntry">
-      <span class="surname">Claude</span>, <span class="forename">Dietrich</span>: <span class="sectionTitle">Art. Domesticus (domestikos). II. Frühmittelalter</span>, in: <span class="bookTitle">Lexikon des Mittelalters Bd. 3</span>, <span class="publicationYear">1986</span>, <span class="pubPages">S. 1183</span>.</p>
+      <span class="surname">Claude</span>, <span class="forename">Dietrich</span>: <span class="sectionTitle">Art. Domesticus (domestikos). II. Frühmittelalter</span>, in: <span class="bookTitle">Lexikon des Mittelalters Bd. 3</span>, <span class="publicationYear">1986</span>, <span class="pubPages">S. S 1183</span>.</p>
    <p class="biblEntry">
       <span class="surname">Claude</span>, <span class="forename">Dietrich</span>: <span class="articleTitle">Niedergang, Renaissance und Ende der Praefekturverwaltung im Westen des römischen Reiches (5.-8. Jahrhundert)</span>, in: <span class="bookTitle">Zeitschrift der Savigny-Stiftung für Rechtsgeschichte: Germanistische Abteilung 114</span> (<span class="publicationYear">1997</span>), <span class="pubPages">S. 352–379</span>.</p>
    <p class="biblEntry">: <span class="sectionTitle">Synode von Paris 556-573</span>, in: <span class="forename">Charles de</span> 
@@ -921,10 +1010,7 @@
       <span class="surname"> Peters-Custot</span> und <span class="forename">Vivien</span> 
       <span class="surname"> Prigent</span>: <span class="bookTitle">Puer Apuliae: mélanges offerts à Jean-Marie Martin</span>, <span class="publicationPlace">Paris</span> 
       <span class="publicationYear">2008</span>.</p>
-   <p class="biblEntry">
-      <span class="surname">Cárcel Ortí</span>, <span class="forename">María Milagros</span>: <span class="bookTitle">Vocabulaire international de la diplomatique</span>, <span class="publicationPlace">Valéncia</span> 
-      <span class="publicationYear">1994</span> (<span class="publicationSeries">Collecció oberta (Valencia) 28</span>).</p>
-   <p class="biblEntry">
+   <p class="biblEntry" id="BL-D">
       <span class="surname">Dahlhaus</span>, <span class="forename">Joachim</span>: <span class="sectionTitle">Rota oder Unterschrift. Zur Unterfertigung päpstlicher Urkunden durch ihre Aussteller in der zweiten Hälfte des 11. Jahrhunderts</span>, in: <span class="forename">Irmgard</span> 
       <span class="surname">Fees</span>, <span class="forename">Andreas</span> 
       <span class="surname"> Hedwig</span> und <span class="forename">Francesco</span> 
@@ -966,7 +1052,7 @@
       <span class="surname">Debus</span>, <span class="forename">Karl Heinz</span>: <span class="articleTitle">Studien zu merowingischen Urkunden und Briefen: Untersuchungen und Texte</span>, in: <span class="bookTitle">Archiv für Diplomatik 14</span> (<span class="publicationYear">1968</span>), <span class="pubPages">S. 1–192</span>.</p>
    <p class="biblEntry">
       <span class="surname">Deichmann</span>, <span class="forename">Friedrich Wilhelm</span>: <span class="sectionTitle">Art. Cella</span>, in: <span class="bookTitle">Reallexikon für Antike und Christentum Bd. 2</span>, <span class="publicationPlace">Stuttgart</span> 
-      <span class="publicationYear">1954</span>, <span class="pubPages">S. 942-944</span>.</p>
+      <span class="publicationYear">1954</span>, <span class="pubPages">S. S 942-944</span>.</p>
    <p class="biblEntry">
       <span class="surname">Delaplace</span>, <span class="forename">Christine</span>: <span class="bookTitle">Aux origines de la paroisse rurale en Gaule méridionale (IV-IXe s.)</span>, <span class="publicationPlace">Paris</span> 
       <span class="publicationYear">2005</span>.</p>
@@ -1153,7 +1239,7 @@
    <p class="biblEntry">
       <span class="surname">Dresken-Weiland</span>, <span class="forename">Jutta</span> und <span class="forename">Wolfram</span> 
       <span class="surname"> Drews</span>: <span class="sectionTitle">Art. Kathedra</span>, in: <span class="bookTitle">Reallexikon für Antike und Christentum Bd. 20</span>, <span class="publicationPlace">Stuttgart</span> 
-      <span class="publicationYear">2004</span>, <span class="pubPages">S. 600-682</span>.</p>
+      <span class="publicationYear">2004</span>, <span class="pubPages">S. S 600-682</span>.</p>
    <p class="biblEntry">
       <span class="surname">Du Cange</span>, <span class="forename">Charles Fresne</span>: <span class="bookTitle">Glossarium mediae et infimae latinitatis</span>, <span class="publicationPlace">Graz</span> 
       <span class="publicationYear">1954</span>.</p>
@@ -1206,7 +1292,7 @@
    <p class="biblEntry">
       <span class="surname">Dümmler</span>, <span class="forename">Ernst</span>: <span class="bookTitle">Poetae Latini aevi Carolini</span>, <span class="publicationPlace">Berlin</span> 
       <span class="publicationYear">1884</span> (<span class="publicationSeries">MGH (Poetae) 2</span>).</p>
-   <p class="biblEntry">
+   <p class="biblEntry" id="BL-E">
       <span class="surname">Ebner</span>, <span class="forename">Herwig</span>: <span class="bookTitle">Das freie Eigen. Ein Beitrag zur Verfassungsgeschichte des Mittelalters</span>, <span class="publicationPlace">Klagenfurt</span> 
       <span class="publicationYear">1969</span> (<span class="publicationSeries">Aus Forschung und Kunst 2</span>).</p>
    <p class="biblEntry">
@@ -1350,6 +1436,12 @@
    <p class="biblEntry">
       <span class="surname">Estey</span>, <span class="forename">Francis N.</span>: <span class="articleTitle">The Meaning of "Placitum" and "Mallum" in the Capitularies</span>, in: <span class="bookTitle">Speculum 22</span> (<span class="publicationYear">1947</span>), <span class="pubPages">S. 435–439</span>.</p>
    <p class="biblEntry">
+      <span class="bookTitle">Études d'histoire dédiées à la mémoire de Henri Pirenne par ses anciens élèves</span>, <span class="publicationPlace">Brüssel</span> 
+      <span class="publicationYear">1937</span>.</p>
+   <p class="biblEntry">
+      <span class="bookTitle">Études d'histoire du droit privé dédiées à Pierre Petot</span>, <span class="publicationPlace">Paris</span> 
+      <span class="publicationYear">1959</span>.</p>
+   <p class="biblEntry">
       <span class="surname">Everett</span>, <span class="forename">Nicholas C.</span>: <span class="sectionTitle">Lay documents and archives in early medieval Spain and Italy, c. 400-700</span>, in: <span class="forename">Warren C.</span> 
       <span class="surname">Brown</span>, <span class="forename">Marios J.</span> 
       <span class="surname"> Costambeys</span>, <span class="forename">Matthew J.</span> 
@@ -1388,9 +1480,7 @@
       <span class="surname">Ewig</span>, <span class="forename">Eugen</span> und <span class="forename">Hartmut</span> 
       <span class="surname"> Atsma</span>: <span class="bookTitle">Spätantikes und fränkisches Gallien</span>, <span class="publicationPlace">München</span> 
       <span class="publicationYear">1979</span>.</p>
-   <p class="biblEntry">
-      <span class="bookTitle">FS Heinz Holzhauer</span>, <span class="publicationYear">2005</span>.</p>
-   <p class="biblEntry">
+   <p class="biblEntry" id="BL-F">
       <span class="surname">Fabricius</span>, <span class="forename">Clara</span>: <span class="articleTitle">Die Litterae Formatae im Frühmittelalter</span>, in: <span class="bookTitle">Archiv für Urkundenforschung 9</span> (<span class="publicationYear">1926</span>), <span class="pubPages">S. 39-86, 168-194</span>.</p>
    <p class="biblEntry">
       <span class="surname">Faivre</span>, <span class="forename">A.</span>: <span class="sectionTitle">Presbyter</span>, in: <span class="forename">Walter</span> 
@@ -1449,6 +1539,11 @@
    <p class="biblEntry">
       <span class="surname">Fetscher</span>, <span class="forename">Iring</span>: <span class="bookTitle">Pipers Handbuch der politischen Ideen. Bd. 2: Mittelalter</span>, <span class="publicationPlace">München</span> 
       <span class="publicationYear">1993</span>.</p>
+   <p class="biblEntry">
+      <span class="surname">Février</span>, <span class="forename">Paul-Albert</span>: <span class="sectionTitle">La marque de l'Antiquité tardive dans le paysage religieux médiéval de la Provence rurale</span>, in: <span class="forename">Michel</span> 
+      <span class="surname">Fixot</span> und <span class="forename">Elisabeth</span> 
+      <span class="surname"> Zadora-Rio</span> (Hgg.), <span class="bookTitle">L'environnement des églises et la topographie religieuse des campagnes médiévales</span>, <span class="publicationPlace">Paris</span> 
+      <span class="publicationYear">1994</span>,  (<span class="publicationSeries">Documents d'archéologie française</span>), <span class="pubPages">S. 27–35</span>.</p>
    <p class="biblEntry">
       <span class="surname">Fichtenau</span>, <span class="forename">Heinrich</span>: <span class="bookTitle">Askese und Laster in der Anschauung des Mittelalters</span>, <span class="publicationPlace">Wien</span> 
       <span class="publicationYear">1948</span>.</p>
@@ -1515,6 +1610,10 @@
       <span class="surname"> Violante</span> (Hgg.), <span class="bookTitle">Informatique et histoire médiévale</span>, <span class="publicationPlace">Rome</span> 
       <span class="publicationYear">1977</span>,  (<span class="publicationSeries">Collection de l'École Française de Rome</span>), <span class="pubPages">S. 169–174</span>.</p>
    <p class="biblEntry">
+      <span class="surname">Fouracre</span>, <span class="forename">Paul</span> und <span class="forename">Wendy</span> 
+      <span class="surname"> Davies</span>: <span class="bookTitle">The settlement of disputes in early medieval Europe</span>, <span class="publicationPlace">Cambridge</span> 
+      <span class="publicationYear">1986</span>.</p>
+   <p class="biblEntry">
       <span class="surname">Fouracre</span>, <span class="forename">Paul J.</span>: <span class="sectionTitle">Placita and the settlement of disputes in Later Merovingian Francia</span>, in: <span class="forename">Paul</span> 
       <span class="surname">Fouracre</span> und <span class="forename">Wendy</span> 
       <span class="surname"> Davies</span> (Hgg.), <span class="bookTitle">The settlement of disputes in early medieval Europe</span>, <span class="publicationPlace">Cambridge</span> 
@@ -1531,10 +1630,6 @@
       <span class="surname">Davies</span> und <span class="forename">Paul J.</span> 
       <span class="surname"> Fouracre</span> (Hgg.), <span class="bookTitle">The languages of gift in the early middle ages</span>, <span class="publicationPlace">Cambridge</span> 
       <span class="publicationYear">2010</span>, <span class="pubPages">S. 62–88</span>.</p>
-   <p class="biblEntry">
-      <span class="surname">Fouracre</span>, <span class="forename">Paul</span> und <span class="forename">Wendy</span> 
-      <span class="surname"> Davies</span>: <span class="bookTitle">The settlement of disputes in early medieval Europe</span>, <span class="publicationPlace">Cambridge</span> 
-      <span class="publicationYear">1986</span>.</p>
    <p class="biblEntry">
       <span class="surname">Frank</span>, <span class="forename">Karl Suso</span>: <span class="sectionTitle">Christliches Mönchtum</span>, in: <span class="forename">Walter</span> 
       <span class="surname">Kasper</span>, <span class="forename">Konrad</span> 
@@ -1559,10 +1654,7 @@
    <p class="biblEntry">
       <span class="surname">Frye</span>, <span class="forename">David</span>: <span class="articleTitle">From locus publicus to locus sanctus: Justice and sacred space in Merovingian Gaul</span>, in: <span class="bookTitle">Nottingham medieval studies 47</span> (<span class="publicationYear">2003</span>), <span class="pubPages">S. 1–20</span>.</p>
    <p class="biblEntry">
-      <span class="surname">Février</span>, <span class="forename">Paul-Albert</span>: <span class="sectionTitle">La marque de l'Antiquité tardive dans le paysage religieux médiéval de la Provence rurale</span>, in: <span class="forename">Michel</span> 
-      <span class="surname">Fixot</span> und <span class="forename">Elisabeth</span> 
-      <span class="surname"> Zadora-Rio</span> (Hgg.), <span class="bookTitle">L'environnement des églises et la topographie religieuse des campagnes médiévales</span>, <span class="publicationPlace">Paris</span> 
-      <span class="publicationYear">1994</span>,  (<span class="publicationSeries">Documents d'archéologie française</span>), <span class="pubPages">S. 27–35</span>.</p>
+      <span class="bookTitle">FS Heinz Holzhauer</span>, <span class="publicationYear">2005</span>.</p>
    <p class="biblEntry">
       <span class="surname">Föller</span>, <span class="forename">Carola</span> und <span class="forename">Fabian</span> 
       <span class="surname"> Schulz</span>: <span class="bookTitle">Osten und Westen 400–600 n. Chr. : Kommunikation, Kooperation und Konflikt</span>, <span class="publicationPlace">Stuttgart</span> 
@@ -1573,7 +1665,7 @@
       <span class="surname">Föller</span> und <span class="forename">Fabian</span> 
       <span class="surname"> Schulz</span> (Hgg.), <span class="bookTitle">Osten und Westen 400–600 n. Chr. : Kommunikation, Kooperation und Konflikt</span>, <span class="publicationPlace">Stuttgart</span> 
       <span class="publicationYear">2016</span>, <span class="pubPages">S. 9–15</span>.</p>
-   <p class="biblEntry">
+   <p class="biblEntry" id="BL-G">
       <span class="surname">Gaffiot</span>, <span class="forename">Félix</span> und <span class="forename">Pierre</span> 
       <span class="surname"> Flobert</span>: <span class="bookTitle">Le Grand Gaffiot: Dictionnaire latin-français</span>, <span class="bookEdition">3. durchg. und verb. Aufl.</span>, <span class="publicationPlace">Paris</span> 
       <span class="publicationYear">2008</span>.</p>
@@ -1927,6 +2019,9 @@
       <span class="surname">Hinkel</span> (Hg.), <span class="bookTitle">Nibelungen Schnipsel. Neues vom alten Epos zwischen Mainz und Worms</span>, <span class="publicationPlace">Mainz</span> 
       <span class="publicationYear">2004</span>, <span class="pubPages">S. 119–142</span>.</p>
    <p class="biblEntry">
+      <span class="surname">Guérard</span>, <span class="forename">Benjamin</span>: <span class="bookTitle">Polyptique de l'abbé Irminon: ou Dénombrement des manses, des serfs et des revenus de l'abbaye de Saint-Germain-des-Prés sous le règne de Charlemagne, publié d'après le manuscrit de la bibliothèque du roi avec des prolégomènes pour servir à l'histoire de la condition des personnes et des terres depuis les invasions des barbares jusqu'à l'institution des communes</span>, <span class="publicationPlace">Paris</span> 
+      <span class="publicationYear">1844</span>.</p>
+   <p class="biblEntry">
       <span class="surname">Guerreau-Jalabert</span>, <span class="forename">Anita</span>: <span class="articleTitle">La désignation des relations et des groupes de parenté en latin médiéval</span>, in: <span class="bookTitle">Archivum latinitatis medii aevi 46-47</span> (<span class="publicationYear">1986-1987</span>), <span class="pubPages">S. 65–108</span>.</p>
    <p class="biblEntry">
       <span class="surname">Guerreau-Jalabert</span>, <span class="forename">Anita</span>: <span class="articleTitle">Qu'est-ce que l'adoptio dans la societe chretienne medievale ?</span>, in: <span class="bookTitle">Médiévales 35</span> (<span class="publicationYear">1998</span>), <span class="pubPages">S. 33–50</span>.</p>
@@ -1979,9 +2074,6 @@
       <span class="surname"> Parisse</span>: <span class="bookTitle">Pratiques de l'écrit documentaire au XIe siècle</span>, <span class="publicationPlace">Paris</span> 
       <span class="publicationYear">1997</span> (<span class="publicationSeries">Bibliothèque de l'École des Chartes 155</span>).</p>
    <p class="biblEntry">
-      <span class="surname">Guérard</span>, <span class="forename">Benjamin</span>: <span class="bookTitle">Polyptique de l'abbé Irminon: ou Dénombrement des manses, des serfs et des revenus de l'abbaye de Saint-Germain-des-Prés sous le règne de Charlemagne, publié d'après le manuscrit de la bibliothèque du roi avec des prolégomènes pour servir à l'histoire de la condition des personnes et des terres depuis les invasions des barbares jusqu'à l'institution des communes</span>, <span class="publicationPlace">Paris</span> 
-      <span class="publicationYear">1844</span>.</p>
-   <p class="biblEntry">
       <span class="surname">Göldel</span>, <span class="forename">Caroline</span>: <span class="bookTitle">Servitium regis und Tafelgüterverzeichnis: Untersuchung zur Wirtschafts- und Verfassungsgeschichte des deutschen Königtums im 12. Jahrhundert</span>, <span class="publicationPlace">Sigmaringen</span> 
       <span class="publicationYear">1997</span> (<span class="publicationSeries">Studien zur Rechts-, Wirtschafts- und Kulturgeschichte 16</span>).</p>
    <p class="biblEntry">
@@ -1993,9 +2085,7 @@
       <span class="surname">Görich</span>, <span class="forename">Knut</span> und <span class="forename">Martin</span> 
       <span class="surname"> Wihoda</span>: <span class="bookTitle">Verwandtschaft - Freundschaft - Feindschaft. Politische Bindungen zwischen dem Reich und Ostmitteleuropa in der Zeit Friedrich Barbarossas</span>, <span class="publicationPlace">Köln [u.a.]</span> 
       <span class="publicationYear">2019</span>.</p>
-   <p class="biblEntry">
-      <span class="bookTitle">HRG</span>, <span class="publicationYear">1984</span>.</p>
-   <p class="biblEntry">
+   <p class="biblEntry" id="BL-H">
       <span class="surname">Haase</span>, <span class="forename">Richard</span>: <span class="articleTitle">Justinian I. und der Frauenraub (raptus)</span>, in: <span class="bookTitle">Zeitschrift der Savigny-Stiftung für Rechtsgeschichte: Romanistische Abteilung 111</span> (<span class="publicationYear">1994</span>), <span class="pubPages">S. 458–470</span>.</p>
    <p class="biblEntry">
       <span class="surname">Habiger-Tuczay</span>, <span class="forename">Christa</span>: <span class="bookTitle">Magie und Magier im Mittelalter</span>, <span class="publicationPlace">München</span> 
@@ -2268,6 +2358,8 @@
       <span class="surname"> Pohl</span>: <span class="bookTitle">Meanings of community across medieval Eurasia. Comparative approaches</span>, <span class="publicationPlace">Leiden</span> 
       <span class="publicationYear">2016</span>.</p>
    <p class="biblEntry">
+      <span class="bookTitle">HRG</span>, <span class="publicationYear">1984</span>.</p>
+   <p class="biblEntry">
       <span class="surname">Humfress</span>, <span class="forename">Caroline</span>: <span class="sectionTitle">Law and custom under Rome</span>, in: <span class="forename">Alice</span> 
       <span class="surname">Rio</span> (Hg.), <span class="bookTitle">Law, Custom and Justice in Late Antiquity and the Early Middle Ages</span>, <span class="publicationPlace">London</span> 
       <span class="publicationYear">2011</span>, <span class="pubPages">S. 23–47</span>.</p>
@@ -2306,7 +2398,7 @@
       <span class="surname">Cancik</span>, <span class="forename">Helmuth</span> 
       <span class="surname"> Schneider</span> und <span class="forename">Manfred</span> 
       <span class="surname"> Landfester</span> (Hgg.), <span class="bookTitle">Der neue Pauly (Onlineversion)</span>, URL: https://referenceworks.brillonline.com/entries/der-neue-pauly/villa-e12204670?s.num=1&amp;s.f.s2_parent=s.f.book.der-neue-pauly&amp;s.q=villa (letzter Aufruf: 09.05.2019).</p>
-   <p class="biblEntry">
+   <p class="biblEntry" id="BL-I">
       <span class="surname">Iglesia Ferreirós</span>, <span class="forename">Aquilino José</span>: <span class="bookTitle">El Dret comú i Catalunya-actes del VI Simposi Internacional, Barcelona, 31 de maig - 1 de juny de 1996</span>, <span class="publicationPlace">Barcelona</span> 
       <span class="publicationYear">1997</span> (<span class="publicationSeries">Estudis. Fundació Noguera 12</span>).</p>
    <p class="biblEntry">
@@ -2339,7 +2431,7 @@
       <span class="publicationYear">1989</span> (<span class="publicationSeries">Corpus Christianorum, Series Latina 113</span>).</p>
    <p class="biblEntry">
       <span class="bookTitle">Italy in the early Middle Ages 476-1000</span>, <span class="publicationYear">2002</span>.</p>
-   <p class="biblEntry">
+   <p class="biblEntry" id="BL-J">
       <span class="surname">Jacobs</span>, <span class="forename">U. K.</span>: <span class="sectionTitle">Stipulatio(n)</span>, in: <span class="forename">Adalbert</span> 
       <span class="surname">Erler</span> und <span class="forename">Ekkehard</span> 
       <span class="surname"> Kaufmann</span> (Hgg.), <span class="bookTitle">Handwörterbuch zur deutschen Rechtsgeschichte Bd. 4</span>, <span class="publicationPlace">Berlin</span> 
@@ -2371,6 +2463,13 @@
       <span class="surname">Kerneis</span> (Hg.), <span class="bookTitle">Une histoire juridique de l'Occident: IIIe-IXe siècle: le droit et la coutume</span>, <span class="publicationPlace">Paris</span> 
       <span class="publicationYear">2018</span>, <span class="pubPages">S. 249–300</span>.</p>
    <p class="biblEntry">
+      <span class="surname">Jégou</span>, <span class="forename">Laurent</span>: <span class="sectionTitle">Les déplacements des 'missi dominici' dans l'Empire carolingien (fin VIIIe - fin IXe siècle)</span>, in: <span class="fullname">Société des Historiens Médiévistes de l'Enseignement Supérieur Public</span> (Hg.), <span class="bookTitle">Des sociétés en mouvement</span>, <span class="publicationPlace">Paris</span> 
+      <span class="publicationYear">2010</span>,  (<span class="publicationSeries">Publications de la Sorbonne Histoire ancienne et médiévale</span>), <span class="pubPages">S. 223–235</span>.</p>
+   <p class="biblEntry">
+      <span class="surname">Jégou</span>, <span class="forename">Laurent</span>: <span class="sectionTitle">Scabini, témoins, boni homines... acteurs de la communauté judiciaire à l'époque carolingienne</span>, in: <span class="forename">Jacques</span> 
+      <span class="surname">Péricard</span> (Hg.), <span class="bookTitle">La part de l'ombre. Artisans du pouvoir et arbitres des rapports sociaux</span>, <span class="publicationPlace">Limoges</span> 
+      <span class="publicationYear">2014</span>,  (<span class="publicationSeries">Histoire</span>), <span class="pubPages">S. 41–56</span>.</p>
+   <p class="biblEntry">
       <span class="surname">Jerg</span>, <span class="forename">Ernst</span>: <span class="bookTitle">Vir venerabilis: Untersuchungen zur Titulatur der Bischöfe in den ausserkirchlichen Texten der Spätantike als Beitrag zur Deutung ihrer öffentlichen Stellung</span>, <span class="publicationPlace">Wien</span> 
       <span class="publicationYear">1970</span> (<span class="publicationSeries">Wiener Beiträge zur Theologie 26</span>).</p>
    <p class="biblEntry">
@@ -2399,14 +2498,7 @@
       <span class="surname">Bannasch</span> und <span class="forename">Hans-Peter</span> 
       <span class="surname"> Lachmann</span> (Hgg.), <span class="bookTitle">Aus Geschichte und ihren Hilfswissenschaften</span>, <span class="publicationPlace">Marburg</span> 
       <span class="publicationYear">1979</span>,  (<span class="publicationSeries">Veröffentlichungen der Historischen Kommission für Hessen</span>), <span class="pubPages">S. 25–54</span>.</p>
-   <p class="biblEntry">
-      <span class="surname">Jégou</span>, <span class="forename">Laurent</span>: <span class="sectionTitle">Les déplacements des 'missi dominici' dans l'Empire carolingien (fin VIIIe - fin IXe siècle)</span>, in: <span class="fullname">Société des Historiens Médiévistes de l'Enseignement Supérieur Public</span> (Hg.), <span class="bookTitle">Des sociétés en mouvement</span>, <span class="publicationPlace">Paris</span> 
-      <span class="publicationYear">2010</span>,  (<span class="publicationSeries">Publications de la Sorbonne Histoire ancienne et médiévale</span>), <span class="pubPages">S. 223–235</span>.</p>
-   <p class="biblEntry">
-      <span class="surname">Jégou</span>, <span class="forename">Laurent</span>: <span class="sectionTitle">Scabini, témoins, boni homines... acteurs de la communauté judiciaire à l'époque carolingienne</span>, in: <span class="forename">Jacques</span> 
-      <span class="surname">Péricard</span> (Hg.), <span class="bookTitle">La part de l'ombre. Artisans du pouvoir et arbitres des rapports sociaux</span>, <span class="publicationPlace">Limoges</span> 
-      <span class="publicationYear">2014</span>,  (<span class="publicationSeries">Histoire</span>), <span class="pubPages">S. 41–56</span>.</p>
-   <p class="biblEntry">
+   <p class="biblEntry" id="BL-K">
       <span class="surname">Kaiser</span>, <span class="forename">Reinhold</span>: <span class="articleTitle">Steuer und Zoll in der Merowingerzeit</span>, in: <span class="bookTitle">Francia 7</span> (<span class="publicationYear">1979</span>), <span class="pubPages">S. 1–18</span>.</p>
    <p class="biblEntry">
       <span class="surname">Kaiser</span>, <span class="forename">Reinhold</span>: <span class="sectionTitle">Teloneum episcopi. Du tonlieu royal au tonlieu épiscopal dans les civitates de la Gaule (VIe-XIIe siècles)</span>, in: <span class="forename">Werner</span> 
@@ -2705,7 +2797,7 @@
       <span class="publicationYear">2007</span>,  (<span class="publicationSeries">Schriften des Historischen Kollegs. Kolloquien</span>), <span class="pubPages">S. 197–215</span>.</p>
    <p class="biblEntry">
       <span class="surname">Köstler</span>, <span class="forename">Rudolf</span>: <span class="articleTitle">"Consuetudo legitime praescripta". Ein Beitrag zur Lehre vom Gewohnheitsrecht und vom Privileg</span>, in: <span class="bookTitle">Zeitschrift der Savigny-Stiftung für Rechtsgeschichte: Kanonistische Abteilung 8</span> (<span class="publicationYear">1918</span>), <span class="pubPages">S. 154–194</span>.</p>
-   <p class="biblEntry">
+   <p class="biblEntry" id="BL-L">
       <span class="bookTitle">L'homme et la route en Europe occidentale au Moyen Âge et aux temps modernes. Deuxième journées internationales d'histoire, 20-22 septembre 1980</span>, <span class="publicationPlace">Auch</span> 
       <span class="publicationYear">1982</span> (<span class="publicationSeries">Flaran 2</span>).</p>
    <p class="biblEntry">
@@ -2803,10 +2895,10 @@
       <span class="surname"> Devroey</span>: <span class="bookTitle">Les élites et la richesse au haut Moyen Âge</span>, <span class="publicationPlace">Turnhout</span> 
       <span class="publicationYear">2010</span>.</p>
    <p class="biblEntry">
-      <span class="articleTitle">Le Trésor de la Langue Française</span>, URL: <span class="pubURL"/> (letzter Aufruf: <span class="pubURLDate"/>).</p>
-   <p class="biblEntry">
       <span class="bookTitle">Le règlement des conflits au Moyen Âge : XXXIe Congrès de la S.H.M.E.S. (Angers, juin 2000)</span>, <span class="publicationPlace">Paris</span> 
       <span class="publicationYear">2001</span>.</p>
+   <p class="biblEntry">
+      <span class="articleTitle">Le Trésor de la Langue Française</span>, URL: <span class="pubURL"/> (letzter Aufruf: <span class="pubURLDate"/>).</p>
    <p class="biblEntry">
       <span class="bookTitle">Leges Alamannorum</span>, <span class="bookEdition">Unveränd. Nachdr. [der] Ed. altera, Hannoverae, Hahn, 1966</span>, <span class="publicationPlace">Hannover</span> 
       <span class="publicationYear">1993</span> (<span class="publicationSeries">Monumenta Germaniae Historica Legum sectio 1 Leges nationum Germanicarum 5,1</span>).</p>
@@ -2814,6 +2906,9 @@
       <span class="surname">Lehmann</span>, <span class="forename">Karl</span> und <span class="forename">Karl August</span> 
       <span class="surname"> Eckhardt</span>: <span class="bookTitle">Leges Alamannorum</span>, <span class="publicationPlace">Hannover</span> 
       <span class="publicationYear">1966</span> (<span class="publicationSeries">MGH (LL nat. Germ.) 5,1</span>).</p>
+   <p class="biblEntry">
+      <span class="surname">Lemaître</span>, <span class="forename">Jean-Loup</span>: <span class="bookTitle">Prieurs et prieurés dans l'occident médiéval</span>, <span class="publicationPlace">Genf</span> 
+      <span class="publicationYear">1987</span> (<span class="publicationSeries">École Pratique des Hautes Études, Sciences Historiques et Philologiques 5/60</span>).</p>
    <p class="biblEntry">
       <span class="surname">Lemarignier</span>, <span class="forename">Jean-François</span>: <span class="sectionTitle">Les actes de droit privé de Saint-Bertin au Haut Moyen Âge: survivances et déclin du droit romain dans la pratique franque</span>, in: <span class="forename">Jean-François</span> 
       <span class="surname">Lemarignier</span> und <span class="forename">Dominique</span> 
@@ -2827,12 +2922,9 @@
       <span class="surname"> Barthélemy</span>: <span class="bookTitle">Structures politiques et religieuses dans la France du haut Moyen Âge</span>, <span class="publicationPlace">Rouen</span> 
       <span class="publicationYear">1995</span> (<span class="publicationSeries">Publications de l'Université de Rouen 206</span>).</p>
    <p class="biblEntry">
-      <span class="surname">Lemaître</span>, <span class="forename">Jean-Loup</span>: <span class="bookTitle">Prieurs et prieurés dans l'occident médiéval</span>, <span class="publicationPlace">Genf</span> 
-      <span class="publicationYear">1987</span> (<span class="publicationSeries">École Pratique des Hautes Études, Sciences Historiques et Philologiques 5/60</span>).</p>
-   <p class="biblEntry">
       <span class="surname">Lemcke</span>, <span class="forename">Lukas</span>: <span class="articleTitle">Evectiones et tractoriae. Identifying the permits for the cursus publicus in the 4th century</span>, in: <span class="bookTitle">Byzantinische Zeitschrift 109</span> (<span class="publicationYear">2016</span>), <span class="pubPages">S. 769–784</span>.</p>
    <p class="biblEntry">
-      <span class="surname">Lentes</span>, <span class="forename">Thomas</span>: <span class="sectionTitle">Art. Zelle</span>, in: <span class="bookTitle">Lexikon des Mittelalters Bd. 9</span>, <span class="publicationYear">1998</span>, <span class="pubPages">S. 520-521</span>.</p>
+      <span class="surname">Lentes</span>, <span class="forename">Thomas</span>: <span class="sectionTitle">Art. Zelle</span>, in: <span class="bookTitle">Lexikon des Mittelalters Bd. 9</span>, <span class="publicationYear">1998</span>, <span class="pubPages">S. S 520-521</span>.</p>
    <p class="biblEntry">
       <span class="surname">Lepsius</span>, <span class="forename">Susanne</span> und <span class="forename">Susanne</span> 
       <span class="surname"> Reichlin</span>: <span class="bookTitle">Fides/Triuwe</span>, <span class="publicationPlace">Berlin</span> 
@@ -2861,6 +2953,10 @@
    <p class="biblEntry">
       <span class="surname">Levy</span>, <span class="forename">Ernst</span>: <span class="bookTitle">Weströmisches Vulgarrecht: Das Obligationenrecht</span>, <span class="publicationPlace">Weimar</span> 
       <span class="publicationYear">1956</span> (<span class="publicationSeries">Forschungen zum römischen Recht 7</span>).</p>
+   <p class="biblEntry">
+      <span class="surname">Lévy</span>, <span class="forename">Jean-Philippe</span> und <span class="forename">André</span> 
+      <span class="surname"> Castaldo</span>: <span class="bookTitle">Histoire du droit civil</span>, <span class="bookEdition">2. Aufl.</span>, <span class="publicationPlace">Paris</span> 
+      <span class="publicationYear">2010</span> (<span class="publicationSeries">Précis Droit privé</span>).</p>
    <p class="biblEntry">
       <span class="surname">Lewis</span>, <span class="forename">Archibald Ross</span>: <span class="articleTitle">The Dukes in the Regnum Francorum, A.D. 550-751</span>, in: <span class="bookTitle">Speculum 51</span> (<span class="publicationYear">1976</span>), <span class="pubPages">S. 381–410</span>.</p>
    <p class="biblEntry">
@@ -2983,10 +3079,6 @@
       <span class="surname"> Pennington</span> (Hgg.), <span class="bookTitle">Proceedings of the Sixth International Congress of Medieval Canon Law. Berkeley, California, 28 July-2 August 1980</span>, <span class="publicationPlace">Città del Vaticano</span> 
       <span class="publicationYear">1985</span>, <span class="pubPages">S. 271–288</span>.</p>
    <p class="biblEntry">
-      <span class="surname">Lévy</span>, <span class="forename">Jean-Philippe</span> und <span class="forename">André</span> 
-      <span class="surname"> Castaldo</span>: <span class="bookTitle">Histoire du droit civil</span>, <span class="bookEdition">2. Aufl.</span>, <span class="publicationPlace">Paris</span> 
-      <span class="publicationYear">2010</span> (<span class="publicationSeries">Précis Droit privé</span>).</p>
-   <p class="biblEntry">
       <span class="surname">Löfstedt</span>, <span class="forename">Bengt</span>: <span class="sectionTitle">Zum spanischen Mittellatein</span>, in: <span class="forename">Bengt</span> 
       <span class="surname">Löfstedt</span> und <span class="forename">Walter</span> 
       <span class="surname"> Berschin</span> (Hgg.), <span class="bookTitle">Ausgewählte Aufsätze zur lateinischen Sprachgeschichte und Philologie</span>, <span class="publicationPlace">Stuttgart</span> 
@@ -3008,7 +3100,7 @@
       <span class="surname"> Werkmüller</span> und <span class="forename">Ruth</span> 
       <span class="surname"> Schmidt-Weigand</span> (Hgg.), <span class="bookTitle">Handwörterbuch zur deutschen Rechtsgeschichte Bd. 2</span>, <span class="publicationPlace">Berlin</span> 
       <span class="publicationYear">2005-2016</span>, <span class="pubPages">S. 1709–1713</span>.</p>
-   <p class="biblEntry">
+   <p class="biblEntry" id="BL-M">
       <span class="surname">Mabillon</span>, <span class="forename">Johannis</span>: <span class="bookTitle">Librorum De Re Diplomatica Supplementum : In Quo Archetypa In His Libris pro regulis proposita, ipsæque regulæ denuo confirmantur, novisque speciminibus &amp; argumentis &amp; illustrantur.</span>, <span class="publicationPlace">Paris</span> 
       <span class="publicationYear">1704</span>.</p>
    <p class="biblEntry">
@@ -3081,7 +3173,6 @@
       <span class="publicationYear">2010</span> (<span class="publicationSeries">Texte zur Forschung 81</span>).</p>
    <p class="biblEntry">
       <span class="surname">Marchal</span>, <span class="forename">Guy Paul</span>: <span class="articleTitle">Was war das weltliche Kanonikerinstitut im Mittelalter? Dom- und Kollegiatstifte. Eine Einführung und eine neue Perspektive</span>, in: <span class="bookTitle">Revue d'histoire ecclésiastique 94</span> (<span class="publicationYear">1999</span>), <span class="pubPages">S. 761–807</span>.</p>
-
 
 
 
@@ -3257,6 +3348,12 @@
       <span class="surname"> Patzold</span>: <span class="bookTitle">Chlodwigs Welt. Organisation von Herrschaft um 500</span>, <span class="publicationPlace">Stuttgart</span> 
       <span class="publicationYear">2014</span> (<span class="publicationSeries">Roma aeterna 3</span>).</p>
    <p class="biblEntry">
+      <span class="bookTitle">Mélanges d'histoire offerts à Ferdinand Lot</span>, <span class="publicationPlace">Paris</span> 
+      <span class="publicationYear">1925</span>.</p>
+   <p class="biblEntry">
+      <span class="bookTitle">Mélanges de droit romain: dédiés à Georges Cornil</span>, <span class="publicationPlace">Paris</span> 
+      <span class="publicationYear">1926</span>.</p>
+   <p class="biblEntry">
       <span class="surname">Melograni</span>, <span class="forename">Piero</span>: <span class="bookTitle">La famiglia Italiana dall'ottocento a oggi</span>, <span class="publicationPlace">Bari</span> 
       <span class="publicationYear">1988</span>.</p>
    <p class="biblEntry">
@@ -3429,12 +3526,6 @@
       <span class="surname"> Laes</span>: <span class="bookTitle">The dark side of childhood in late antiquity and the Middle Ages. Unwanted, disabled and lost</span>, <span class="publicationPlace">Oxford u.a.</span> 
       <span class="publicationYear">2011</span>.</p>
    <p class="biblEntry">
-      <span class="bookTitle">Mélanges d'histoire offerts à Ferdinand Lot</span>, <span class="publicationPlace">Paris</span> 
-      <span class="publicationYear">1925</span>.</p>
-   <p class="biblEntry">
-      <span class="bookTitle">Mélanges de droit romain: dédiés à Georges Cornil</span>, <span class="publicationPlace">Paris</span> 
-      <span class="publicationYear">1926</span>.</p>
-   <p class="biblEntry">
       <span class="surname">Möller</span>, <span class="forename">Ch.</span> und <span class="forename">J.</span> 
       <span class="surname"> Katz</span>: <span class="sectionTitle">Gemeinde</span>, in: <span class="forename">Gerhard</span> 
       <span class="surname">Müller</span> (Hg.), <span class="bookTitle">Theologische Realenzyklopädie</span>, <span class="publicationPlace">Berlin and Boston</span> 
@@ -3472,7 +3563,7 @@
    <p class="biblEntry">
       <span class="surname">Müller-Mertens</span>, <span class="forename">Eckhard</span>: <span class="bookTitle">Karl der Grosse, Ludwig der Fromme und die Freien. Wer waren die liberi homines der karolingischen Kapitularien (742/743 - 832)? Ein Beitrag zur Sozialgeschichte und Sozialpolitik des Frankenreiches</span>, <span class="publicationPlace">Berlin</span> 
       <span class="publicationYear">1963</span> (<span class="publicationSeries">Forschungen zur mittelalterlichen Geschichte 10</span>).</p>
-   <p class="biblEntry">
+   <p class="biblEntry" id="BL-N">
       <span class="surname">Neesen</span>, <span class="forename">Lutz</span>: <span class="articleTitle">Die Entwicklung der Leistungen und Ämter (munera et honores) im römischen Kaiserreich des zweiten bis vierten Jahrhunderts</span>, in: <span class="bookTitle">Historia. Zeitschrift für Alte Geschichte 30</span> (<span class="publicationYear">1981</span>), <span class="pubPages">S. 203–235</span>.</p>
    <p class="biblEntry">
       <span class="surname">Nehlsen</span>, <span class="forename">Hermann</span>: <span class="bookTitle">Sklavenrecht zwischen Antike und Mittelalter: Germanisches und römisches Recht in den germanischen Rechtsaufzeichnungen. Bd. 1: Ostgoten, Westgoten, Franken, Langobarden</span>, <span class="publicationPlace">Frankfurt a. M</span> 
@@ -3576,6 +3667,10 @@
    <p class="biblEntry">
       <span class="surname">Nörr</span>, <span class="forename">Dieter</span>: <span class="bookTitle">Die Entstehung der longi temporis praescriptio: Studien zum Einfluß der Zeit im Recht und zur Rechtspolitik in der Kaiserzeit</span>, <span class="publicationPlace">Köln u.a.</span> 
       <span class="publicationYear">1969</span> (<span class="publicationSeries">Arbeitsgemeinschaft für Forschung des Landes Nordrhein-Westfalen. Geisteswissenschaften 156</span>).</p>
+   <p class="biblEntry" id="BL-O">
+      <span class="surname">Ó Carragáin</span>, <span class="forename">Tomás</span> und <span class="forename">Sam</span> 
+      <span class="surname"> Turner</span>: <span class="bookTitle">Making Christian landscapes in Atlantic Europe: conversion and consolidation in the early Middle Ages</span>, <span class="publicationPlace">Cork</span> 
+      <span class="publicationYear">2016</span>.</p>
    <p class="biblEntry">
       <span class="surname">Obermeier</span>, <span class="forename">Monika</span>: <span class="bookTitle">"Ancilla": Beiträge zur Geschichte der unfreien Frauen im Frühmittelalter.</span>, <span class="publicationPlace">Pfaffenweiler</span> 
       <span class="publicationYear">1994</span> (<span class="publicationSeries">Frauen in Geschichte und Gesellschaft 32</span>).</p>
@@ -3629,7 +3724,7 @@
       <span class="publicationYear">1968</span> (<span class="publicationSeries">Le droit familial 3</span>).</p>
    <p class="biblEntry">
       <span class="bookTitle">Oxford English Dictionary Online</span>, <span class="bookEdition">3. Aufl.</span>, <span class="publicationYear">2021</span>.</p>
-   <p class="biblEntry">
+   <p class="biblEntry" id="BL-P">
       <span class="surname">Paget</span>, <span class="forename">James Carleton</span> und <span class="forename">Joachim</span> 
       <span class="surname"> Schaper</span>: <span class="bookTitle">The new Cambridge history of the bible. 2. From 600 to 1450</span>, <span class="publicationPlace">Cambridge</span> 
       <span class="publicationYear">2012</span>.</p>
@@ -3716,6 +3811,14 @@
       <span class="surname">Perels</span>, <span class="forename">Ernst</span>: <span class="bookTitle">Die kirchlichen Zehnten im karolingischen Reiche</span>, <span class="publicationPlace">[Universität Berlin]</span> 
       <span class="publicationYear">1904</span>.</p>
    <p class="biblEntry">
+      <span class="surname">Péricard</span>, <span class="forename">Jacques</span>: <span class="bookTitle">La part de l'ombre. Artisans du pouvoir et arbitres des rapports sociaux: (VIIIe - XVe siècles)</span>, <span class="publicationPlace">Limoges</span> 
+      <span class="publicationYear">2014</span> (<span class="publicationSeries">Histoire</span>).</p>
+   <p class="biblEntry">
+      <span class="surname">Péricard</span>, <span class="forename">Jacques</span>: <span class="sectionTitle">L'excommunication dans le royaume franc. Quelques remarques sur la législation canonique et ses contournements (Ve-IXe siècle)</span>, in: <span class="forename">Geneviève</span> 
+      <span class="surname">Bührer-Thierry</span> und <span class="forename">Stéphane</span> 
+      <span class="surname"> Gioanni</span> (Hgg.), <span class="bookTitle">Exclure de la communauté chrétienne</span>, <span class="publicationPlace">Turnhout</span> 
+      <span class="publicationYear">2015</span>,  (<span class="publicationSeries">Collection Haut Moyen Âge</span>), <span class="pubPages">S. 21–38</span>.</p>
+   <p class="biblEntry">
       <span class="surname">Perrin</span>, <span class="forename">Charles Edmond</span>: <span class="sectionTitle">De la condition des terres dites "ancingae"</span>, in: <span class="bookTitle">Mélanges d'histoire offerts à Ferdinand Lot</span>, <span class="publicationPlace">Paris</span> 
       <span class="publicationYear">1925</span>, <span class="pubPages">S. 619–640</span>.</p>
    <p class="biblEntry">
@@ -3756,17 +3859,17 @@
       <span class="surname">Moran</span> (Hg.), <span class="bookTitle">Early medieval Ireland and Europe: chronology, contacts, scholarship; Festschrift for Dáibhí Ó Cróinín</span>, <span class="publicationPlace">Turnhout</span> 
       <span class="publicationYear">2015</span>,  (<span class="publicationSeries">Studia traditionis theologiae</span>), <span class="pubPages">S. 425–440</span>.</p>
    <p class="biblEntry">
+      <span class="surname">Piétri</span>, <span class="forename">Luce</span>: <span class="articleTitle">Les abbés de basilique dans la Gaule du VIe siècle</span>, in: <span class="bookTitle">Revue d'histoire de l'église de France 69</span> (<span class="publicationYear">1983</span>), <span class="pubPages">S. 5–28</span>.</p>
+   <p class="biblEntry">
+      <span class="surname">Piétri</span>, <span class="forename">Luce</span>: <span class="bookTitle">Province ecclésiastique de Tours (Lugdunensis tertia)</span>, <span class="publicationPlace">Paris</span> 
+      <span class="publicationYear">1987</span> (<span class="publicationSeries">Topographie chrétienne des cités de la Gaule des origines au milieu du VIIIe siècle 5</span>).</p>
+   <p class="biblEntry">
       <span class="surname">Pilch</span>, <span class="forename">Martin</span>: <span class="bookTitle">Der Rahmen der Rechtsgewohnheiten: Kritik des Normensystemdenkens entwickelt am Rechtsbegriff der mittelalterlichen Rechtsgeschichte</span>, <span class="publicationPlace">Wien u.a.</span> 
       <span class="publicationYear">2009</span>.</p>
    <p class="biblEntry">
       <span class="surname">Pirson</span>, <span class="forename">Jules</span>: <span class="articleTitle">Le latin des formules mérovingiennes et carolingiennes</span>, in: <span class="bookTitle">Romanische Forschungen 26</span> (<span class="publicationYear">1909</span>), <span class="pubPages">S. 837–944</span>.</p>
    <p class="biblEntry">
       <span class="surname">Pivec</span>, <span class="forename">Karl</span>: <span class="articleTitle">Servus und Servitium in den frühmittelalterlichen Salzburger Quellen</span>, in: <span class="bookTitle">Südost-Forschungen 14</span> (<span class="publicationYear">1955</span>), <span class="pubPages">S. 55–66</span>.</p>
-   <p class="biblEntry">
-      <span class="surname">Piétri</span>, <span class="forename">Luce</span>: <span class="articleTitle">Les abbés de basilique dans la Gaule du VIe siècle</span>, in: <span class="bookTitle">Revue d'histoire de l'église de France 69</span> (<span class="publicationYear">1983</span>), <span class="pubPages">S. 5–28</span>.</p>
-   <p class="biblEntry">
-      <span class="surname">Piétri</span>, <span class="forename">Luce</span>: <span class="bookTitle">Province ecclésiastique de Tours (Lugdunensis tertia)</span>, <span class="publicationPlace">Paris</span> 
-      <span class="publicationYear">1987</span> (<span class="publicationSeries">Topographie chrétienne des cités de la Gaule des origines au milieu du VIIIe siècle 5</span>).</p>
    <p class="biblEntry">
       <span class="surname">Planitz</span>, <span class="forename">Hans</span>: <span class="bookTitle">Die deutsche Stadt im Mittelalter: Von der Römerzeit bis zu den Zunftkämpfen</span>, <span class="bookEdition">5. Aufl.</span>, <span class="publicationPlace">Wien u.a.</span> 
       <span class="publicationYear">1997</span>.</p>
@@ -3867,15 +3970,7 @@
       <span class="surname">Prou</span>, <span class="forename">Maurice</span> und <span class="forename">Alexandre</span> 
       <span class="surname"> Vidier</span>: <span class="bookTitle">Recueil des Chartes de l'abbaye de Saint-Benoît-sur-Loire: Tome 1</span>, <span class="publicationPlace">Paris</span> 
       <span class="publicationYear">1907</span>.</p>
-   <p class="biblEntry">
-      <span class="surname">Péricard</span>, <span class="forename">Jacques</span>: <span class="bookTitle">La part de l'ombre. Artisans du pouvoir et arbitres des rapports sociaux: (VIIIe - XVe siècles)</span>, <span class="publicationPlace">Limoges</span> 
-      <span class="publicationYear">2014</span> (<span class="publicationSeries">Histoire</span>).</p>
-   <p class="biblEntry">
-      <span class="surname">Péricard</span>, <span class="forename">Jacques</span>: <span class="sectionTitle">L'excommunication dans le royaume franc. Quelques remarques sur la législation canonique et ses contournements (Ve-IXe siècle)</span>, in: <span class="forename">Geneviève</span> 
-      <span class="surname">Bührer-Thierry</span> und <span class="forename">Stéphane</span> 
-      <span class="surname"> Gioanni</span> (Hgg.), <span class="bookTitle">Exclure de la communauté chrétienne</span>, <span class="publicationPlace">Turnhout</span> 
-      <span class="publicationYear">2015</span>,  (<span class="publicationSeries">Collection Haut Moyen Âge</span>), <span class="pubPages">S. 21–38</span>.</p>
-   <p class="biblEntry">
+   <p class="biblEntry" id="BL-R">
       <span class="surname">Radding</span>, <span class="forename">Charles</span> und <span class="forename">Antonio</span> 
       <span class="surname"> Ciaralli</span>: <span class="bookTitle">The Corpus iuris civilis in the Middle Ages: Manuscripts and transmission from the sixth century to the juristic revival</span>, <span class="publicationPlace">Leiden and Boston</span> 
       <span class="publicationYear">2010</span>.</p>
@@ -3887,6 +3982,10 @@
    <p class="biblEntry">
       <span class="surname">Rathmann</span>, <span class="forename">Michael</span>: <span class="bookTitle">Untersuchungen zu den Reichsstraßen in den westlichen Provinzen des Imperium Romanum</span>, <span class="publicationPlace">Mainz</span> 
       <span class="publicationYear">2003</span> (<span class="publicationSeries">Bonner Jahrbücher. Beihefte 55</span>).</p>
+   <p class="biblEntry">
+      <span class="surname">Réal</span>, <span class="forename">Isabelle</span>: <span class="sectionTitle">Discours multiples, pluralité des pratiques: séparations, divorces, répudiations, dans l'Europe chrétienne du haut Moyen Âge (VIe-IXe siècles) d'après les sources normatives et narratives</span>, in: <span class="forename">Emmanuelle</span> 
+      <span class="surname">Santinelli</span> (Hg.), <span class="bookTitle">Répudiation, séparation, divorce dans l'Occident médiéval</span>, <span class="publicationPlace">Valenciennes</span> 
+      <span class="publicationYear">2007</span>, <span class="pubPages">S. 157–180</span>.</p>
    <p class="biblEntry">
       <span class="bookTitle">Reallexikon für Antike und Christentum</span>, <span class="publicationPlace">Stuttgart</span> 
       <span class="publicationYear">1950</span>.</p>
@@ -4008,11 +4107,6 @@
       <span class="surname"> Tischler</span> (Hgg.), <span class="bookTitle">Indogermanica Europaea</span>, <span class="publicationPlace">Graz</span> 
       <span class="publicationYear">1989</span>, <span class="pubPages">S. 225–240</span>.</p>
    <p class="biblEntry">
-      <span class="surname">Rosenwein</span>, <span class="forename">Barbara H.</span>: <span class="bookTitle">To Be the Neighbor of St. Peter: The Social Meaning of Cluny's Property, 909-1049</span>, <span class="publicationPlace">Ithaca and New York u.a.</span> 
-      <span class="publicationYear">1989</span>.</p>
-   <p class="biblEntry">
-      <span class="surname">Rossignol</span>, <span class="forename">Sébastien</span>: <span class="articleTitle">Civitas in Early Medieval Central Europe-Stronghold or District?</span>, in: <span class="bookTitle">The medieval history journal 14</span> (<span class="publicationYear">2011</span>), <span class="pubPages">S. 71–99</span>.</p>
-   <p class="biblEntry">
       <span class="surname">Rosé</span>, <span class="forename">Isabelle</span>: <span class="bookTitle">Construire une sociéte seigneuriale: Itinéraire et ecclésiologie de l'abbé Odon de Cluny</span>, <span class="publicationPlace">Turnhout</span> 
       <span class="publicationYear">2008</span> (<span class="publicationSeries">Collection d'études médiévales de Nice 8</span>).</p>
    <p class="biblEntry">
@@ -4021,6 +4115,11 @@
       <span class="surname"> Feller</span> und <span class="forename">Jean-Pierre</span> 
       <span class="surname"> Devroey</span> (Hgg.), <span class="bookTitle">Les élites et la richesse au haut Moyen Âge</span>, <span class="publicationPlace">Turnhout</span> 
       <span class="publicationYear">2010</span>, <span class="pubPages">S. 113–138</span>.</p>
+   <p class="biblEntry">
+      <span class="surname">Rosenwein</span>, <span class="forename">Barbara H.</span>: <span class="bookTitle">To Be the Neighbor of St. Peter: The Social Meaning of Cluny's Property, 909-1049</span>, <span class="publicationPlace">Ithaca and New York u.a.</span> 
+      <span class="publicationYear">1989</span>.</p>
+   <p class="biblEntry">
+      <span class="surname">Rossignol</span>, <span class="forename">Sébastien</span>: <span class="articleTitle">Civitas in Early Medieval Central Europe-Stronghold or District?</span>, in: <span class="bookTitle">The medieval history journal 14</span> (<span class="publicationYear">2011</span>), <span class="pubPages">S. 71–99</span>.</p>
    <p class="biblEntry">
       <span class="surname">Roth</span>, <span class="forename">Andreas</span>: <span class="sectionTitle">Art. Wergeld. I. Germanisches und Deutsches Recht</span>, in: <span class="bookTitle">Lexikon des Mittelalters Bd. 8</span>, <span class="publicationYear">1997</span>, <span class="pubPages">S. 2199–2201</span>.</p>
    <p class="biblEntry">
@@ -4043,16 +4142,12 @@
       <span class="publicationYear">1859-1871</span>.</p>
    <p class="biblEntry">
       <span class="surname">Rubenson</span>, <span class="forename">Samuel</span> und <span class="forename">Christian</span> 
-      <span class="surname"> Hornung</span>: <span class="sectionTitle">Art. Mönchtum I (Idee u. Geschichte)</span>, in: <span class="bookTitle">Reallexikon für Antike und Christentum Bd. 24</span>, <span class="publicationYear">2012</span>, <span class="pubPages">S. 1009-1064</span>.</p>
+      <span class="surname"> Hornung</span>: <span class="sectionTitle">Art. Mönchtum I (Idee u. Geschichte)</span>, in: <span class="bookTitle">Reallexikon für Antike und Christentum Bd. 24</span>, <span class="publicationYear">2012</span>, <span class="pubPages">S. S 1009-1064</span>.</p>
    <p class="biblEntry">
       <span class="surname">Runge</span>, <span class="forename">Wolf-Dieter</span>, <span class="forename">Rudolf</span> 
       <span class="surname"> Pokorny</span> und <span class="forename">Martina</span> 
       <span class="surname"> Stratmann</span>: <span class="bookTitle">Monumenta Germaniae Historica. Capitula episcoporum. Bd. 2</span>, <span class="publicationPlace">Hannover</span> 
       <span class="publicationYear">1995</span> (<span class="publicationSeries">Monumenta Germaniae Historica. Capitula episcoporum 2</span>).</p>
-   <p class="biblEntry">
-      <span class="surname">Réal</span>, <span class="forename">Isabelle</span>: <span class="sectionTitle">Discours multiples, pluralité des pratiques: séparations, divorces, répudiations, dans l'Europe chrétienne du haut Moyen Âge (VIe-IXe siècles) d'après les sources normatives et narratives</span>, in: <span class="forename">Emmanuelle</span> 
-      <span class="surname">Santinelli</span> (Hg.), <span class="bookTitle">Répudiation, séparation, divorce dans l'Occident médiéval</span>, <span class="publicationPlace">Valenciennes</span> 
-      <span class="publicationYear">2007</span>, <span class="pubPages">S. 157–180</span>.</p>
    <p class="biblEntry">
       <span class="surname">Röckelein</span>, <span class="forename">Hedwig</span>: <span class="sectionTitle">Schätze in Altären. Profane Gebrauchsgegenstände im sakralen Raum</span>, in: <span class="forename">Lukas</span> 
       <span class="surname">Burkart</span>, <span class="forename">Philippe</span> 
@@ -4107,7 +4202,7 @@
       <span class="surname"> Jokisch</span> und <span class="forename">Maria</span> 
       <span class="surname"> Macuch</span> (Hgg.), <span class="bookTitle">Transferprozesse in spätantiken Rechtssystemen</span>, <span class="publicationPlace">Wiesbaden</span> 
       <span class="publicationYear">2017</span>,  (<span class="publicationSeries">Episteme in Bewegung</span>), <span class="pubPages">S. 105–119</span>.</p>
-   <p class="biblEntry">
+   <p class="biblEntry" id="BL-S">
       <span class="surname">Saar</span>, <span class="forename">Stefan Chr.</span>: <span class="bookTitle">Ehe - Scheidung - Wiederheirat: Zur Geschichte des Ehe- und des Ehescheidungsrechts im Frühmittelalter (6.-10. Jahrhundert)</span>, <span class="publicationPlace">Münster</span> 
       <span class="publicationYear">2002</span> (<span class="publicationSeries">Ius vivens Abt. B, Rechtsgeschichtliche Abhandlungen 6</span>).</p>
    <p class="biblEntry">
@@ -4189,13 +4284,13 @@
    <p class="biblEntry">
       <span class="surname">Schatz</span>, <span class="forename">Klaus</span>: <span class="sectionTitle">Art. Papst, Papsttum. 1. Begriff und Ursprung</span>, in: <span class="forename">Bruno</span> 
       <span class="surname">Steimer</span> (Hg.), <span class="bookTitle">Lexikon der Päpste und des Papsttums</span>, <span class="publicationPlace">Freiburg i. Br.</span> 
-      <span class="publicationYear">2001</span>, <span class="pubPages">S. 519-521</span>.</p>
+      <span class="publicationYear">2001</span>, <span class="pubPages">S. S 519-521</span>.</p>
    <p class="biblEntry">
       <span class="surname">Schefers</span>, <span class="forename">Hermann</span>: <span class="bookTitle">Einhard: Studien zu Leben und Werk; dem Gedenken an Helmut Beumann gewidmet</span>, <span class="publicationPlace">Darmstadt</span> 
       <span class="publicationYear">1997</span> (<span class="publicationSeries">Arbeiten der Hessischen Historischen Kommission 12</span>).</p>
    <p class="biblEntry">
       <span class="surname">Scherner</span>, <span class="forename">Karl Otto</span>: <span class="sectionTitle">Art. Besitz (possessio). III. Germanisches und deutsches Recht</span>, in: <span class="bookTitle">Lexikon des Mittelalters Bd. 1</span>, <span class="publicationPlace">München [u.a.]</span> 
-      <span class="publicationYear">1980</span>, <span class="pubPages">S. 2067-2068</span>.</p>
+      <span class="publicationYear">1980</span>, <span class="pubPages">S. S 2067-2068</span>.</p>
    <p class="biblEntry">
       <span class="surname">Scherner</span>, <span class="forename">Karl Otto</span>: <span class="sectionTitle">Art. Kauf</span>, in: <span class="forename">Albrecht</span> 
       <span class="surname">Cordes</span>, <span class="forename">Heiner</span> 
@@ -4502,17 +4597,17 @@
    <p class="biblEntry">
       <span class="surname">Silber</span>, <span class="forename">Ilana Friedrich</span>: <span class="articleTitle">Gift-giving in the great traditions: monasteries in the medieval West</span>, in: <span class="bookTitle">Archives européennes de sociologie 36</span> (<span class="publicationYear">1995</span>), <span class="pubPages">S. 209–243</span>.</p>
    <p class="biblEntry">
-      <span class="surname">Simon</span>, <span class="forename">Dieter</span>: <span class="bookTitle">Studien zur Praxis der Stipulationsklausel</span>, <span class="publicationPlace">München</span> 
-      <span class="publicationYear">1964</span> (<span class="publicationSeries">Münchener Beiträge zur Papyrusforschung und antiken Rechtsgeschichte 48</span>).</p>
-   <p class="biblEntry">
-      <span class="surname">Simon</span>, <span class="forename">Dieter</span>: <span class="bookTitle">Akten des 26. Deutschen Rechtshistorikertages Frankfurt am Main, 22. bis 26. September 1986</span>, <span class="publicationPlace">Frankfurt a. M</span> 
-      <span class="publicationYear">1987</span> (<span class="publicationSeries">Studien zur Europäischen Rechtsgeschichte 30</span>).</p>
-   <p class="biblEntry">
       <span class="surname">Siméant</span>, <span class="forename">Clarisse</span>: <span class="sectionTitle">Le privilège dans le droit canonique médiéval: une categorie juridique transposable au droit français</span>, in: <span class="forename">Orazio</span> 
       <span class="surname">Condorelli</span>, <span class="forename">Mathias</span> 
       <span class="surname"> Schmoeckel</span> und <span class="forename">Franck</span> 
       <span class="surname"> Roumy</span> (Hgg.), <span class="bookTitle">Der Einfluss der Kanonistik auf die europäische Rechtskultur</span>, <span class="publicationPlace">Köln</span> 
       <span class="publicationYear">2009</span>,  (<span class="publicationSeries">Norm und Struktur</span>), <span class="pubPages">S. 409–424</span>.</p>
+   <p class="biblEntry">
+      <span class="surname">Simon</span>, <span class="forename">Dieter</span>: <span class="bookTitle">Studien zur Praxis der Stipulationsklausel</span>, <span class="publicationPlace">München</span> 
+      <span class="publicationYear">1964</span> (<span class="publicationSeries">Münchener Beiträge zur Papyrusforschung und antiken Rechtsgeschichte 48</span>).</p>
+   <p class="biblEntry">
+      <span class="surname">Simon</span>, <span class="forename">Dieter</span>: <span class="bookTitle">Akten des 26. Deutschen Rechtshistorikertages Frankfurt am Main, 22. bis 26. September 1986</span>, <span class="publicationPlace">Frankfurt a. M</span> 
+      <span class="publicationYear">1987</span> (<span class="publicationSeries">Studien zur Europäischen Rechtsgeschichte 30</span>).</p>
    <p class="biblEntry">
       <span class="surname">Sirks</span>, <span class="forename">Adriaan Johan Boudewijn</span>: <span class="sectionTitle">The Sources of the Code.</span>, in: <span class="forename">Jill D.</span> 
       <span class="surname">Harries</span> und <span class="forename">Ian N.</span> 
@@ -4545,11 +4640,11 @@
       <span class="fullname">Societas Aperiendis Fontibus Rerum Germanicarum Medii Aevi</span>: <span class="bookTitle">Epistolae Karolini aevi (V)</span>, <span class="publicationPlace">Berlin</span> 
       <span class="publicationYear">1928</span> (<span class="publicationSeries">MGH Epp. 7</span>).</p>
    <p class="biblEntry">
-      <span class="fullname">Société Jean Bodin</span>: <span class="bookTitle">L'enfant. Bd. 2. Europe médiévale et moderne</span>, <span class="publicationPlace">Brüssel</span> 
-      <span class="publicationYear">1976</span>.</p>
-   <p class="biblEntry">
       <span class="fullname">Société des Historiens Médiévistes de l'Enseignement Supérieur Public</span>: <span class="bookTitle">Des sociétés en mouvement: Migrations et mobilité au Moyen Âge</span>, <span class="publicationPlace">Paris</span> 
       <span class="publicationYear">2010</span> (<span class="publicationSeries">Publications de la Sorbonne Histoire ancienne et médiévale 104</span>).</p>
+   <p class="biblEntry">
+      <span class="fullname">Société Jean Bodin</span>: <span class="bookTitle">L'enfant. Bd. 2. Europe médiévale et moderne</span>, <span class="publicationPlace">Brüssel</span> 
+      <span class="publicationYear">1976</span>.</p>
    <p class="biblEntry">
       <span class="surname">Soliva</span>, <span class="forename">Claudio</span>: <span class="articleTitle">Römisches Recht in Churrätien</span>, in: <span class="bookTitle">Jahrbuch der Historisch-Antiquarischen Gesellschaft von Graubünden 116</span> (<span class="publicationYear">1986</span>), <span class="pubPages">S. 189–206</span>.</p>
    <p class="biblEntry">
@@ -4675,7 +4770,7 @@
       <span class="surname">Szaivert</span>, <span class="forename">Willy</span>: <span class="articleTitle">Die Entstehung und Entwicklung der Klosterexemtion bis zum Ausgang des 11. Jahrhunderts</span>, in: <span class="bookTitle">Mitteilungen des Instituts für Österreichische Geschichtsforschung 59</span> (<span class="publicationYear">1951</span>), <span class="pubPages">S. 265–298</span>.</p>
    <p class="biblEntry">
       <span class="surname">Söllner</span>, <span class="forename">Alfred</span>: <span class="articleTitle">Bona fides - guter Glaube?</span>, in: <span class="bookTitle">Zeitschrift der Savigny-Stiftung für Rechtsgeschichte: Romanistische Abteilung 122</span> (<span class="publicationYear">2005</span>), <span class="pubPages">S. 1–61</span>.</p>
-   <p class="biblEntry">
+   <p class="biblEntry" id="BL-T">
       <span class="surname">Tamassia</span>, <span class="forename">Nino</span>: <span class="articleTitle">Tinodo</span>, in: <span class="bookTitle">Atti del Reale Istituto veneto di scienze, lettere ed arti 90</span> (<span class="publicationYear">1930-1931</span>), <span class="pubPages">S. 593–595</span>.</p>
    <p class="biblEntry">
       <span class="surname">Tamassia</span>, <span class="forename">Nino</span>: <span class="sectionTitle">La falcidia nei più antichi documenti del Medio evo</span>, in: <span class="bookTitle">Scritti di storia giuridica pubblicati a cura della Facoltà di Giurisprudenza dell'Università di Padova Bd. 3</span>, <span class="publicationPlace">Padua</span> 
@@ -4766,7 +4861,7 @@
    <p class="biblEntry">
       <span class="surname">Tyler</span>, <span class="forename">Elizabeth M.</span>: <span class="bookTitle">Treasure in the medieval west</span>, <span class="publicationPlace">York</span> 
       <span class="publicationYear">2000</span>.</p>
-   <p class="biblEntry">
+   <p class="biblEntry" id="BL-U">
       <span class="surname">Ubl</span>, <span class="forename">Karl</span>: <span class="bookTitle">Sinnstiftungen eines Rechtsbuchs: die Lex Salica im Frankenreich</span>, <span class="publicationPlace">Ostfildern</span> 
       <span class="publicationYear">2016</span> (<span class="publicationSeries">Quellen und Forschungen zum Recht im Mittelalter 9</span>).</p>
    <p class="biblEntry">
@@ -4783,6 +4878,13 @@
    <p class="biblEntry">
       <span class="bookTitle">Untersuchungen zu Kloster und Stift</span>, <span class="publicationPlace">Göttingen</span> 
       <span class="publicationYear">1980</span> (<span class="publicationSeries">Veröffentlichungen des Max-Planck-Instituts für Geschichte 68</span>).</p>
+   <p class="biblEntry" id="BL-V">
+      <span class="surname">van Dülmen</span>, <span class="forename">Richard</span>: <span class="bookTitle">Armut, Liebe, Ehre. Studien zur historischen Kulturforschung</span>, <span class="publicationPlace">Frankfurt am Main</span> 
+      <span class="publicationYear">1988</span>.</p>
+   <p class="biblEntry">
+      <span class="surname">van Goethem</span>, <span class="forename">Herman</span> und <span class="forename">Laurent L.</span> 
+      <span class="surname"> Waelkens</span>: <span class="bookTitle">Libertés, pluralisme et droit: Une approche historique. Actes du colloque d'Anvers, 27-30 mai 1993, Société d'histoire du droit</span>, <span class="publicationPlace">Bruxelles</span> 
+      <span class="publicationYear">1995</span>.</p>
    <p class="biblEntry">
       <span class="surname">Vandendriessche</span>, <span class="forename">Sarah</span>: <span class="bookTitle">Possessio und Dominium im postklassischen römischen Recht: Eine Überprüfung von Levy's Vulgarrechtstheorie anhand der Quellen des Codex Theodosianus und der Posttheodosianischen Novellen</span>, <span class="publicationPlace">Hamburg</span> 
       <span class="publicationYear">2006</span> (<span class="publicationSeries">Schriftenreihe Rechtsgeschichtliche Studien 16</span>).</p>
@@ -4836,6 +4938,24 @@
    <p class="biblEntry">
       <span class="surname">Voltelini</span>, <span class="forename">Hans von</span>: <span class="articleTitle">Prekarie und Benefizium</span>, in: <span class="bookTitle">Vierteljahrschrift für Sozial- und Wirtschaftsgeschichte 16</span> (<span class="publicationYear">1922</span>), <span class="pubPages">S. 259–306</span>.</p>
    <p class="biblEntry">
+      <span class="surname">von Campenhausen</span>, <span class="forename">Hans</span>: <span class="sectionTitle">Die Anfänge des Priesterbegriffs in der alten Kirche</span>, in: <span class="forename">Hans</span> 
+      <span class="surname">von Campenhausen</span> (Hg.), <span class="bookTitle">Tradition und Leben</span>, <span class="publicationPlace">Tübingen</span> 
+      <span class="publicationYear">1960</span>, <span class="pubPages">S. 272–289</span>.</p>
+   <p class="biblEntry">
+      <span class="surname">von Campenhausen</span>, <span class="forename">Hans</span>: <span class="bookTitle">Tradition und Leben</span>, <span class="publicationPlace">Tübingen</span> 
+      <span class="publicationYear">1960</span>.</p>
+   <p class="biblEntry">
+      <span class="surname">von Euw</span>, <span class="forename">Anton</span>, <span class="forename">Peter</span> 
+      <span class="surname"> Schreiner</span> und <span class="forename">Gudrun</span> 
+      <span class="surname"> Sporbeck</span>: <span class="bookTitle">Kaiserin Theophanu. Begegnung des Ostens und Westens um die Wende des ersten Jahrtausends. Gedenkschrift des Kölner Schnütgen-Museums zum 1000. Todesjahr der Kaiserin</span>, <span class="publicationPlace">Köln</span> 
+      <span class="publicationYear">1991</span>.</p>
+   <p class="biblEntry">
+      <span class="surname">von Hartel</span>, <span class="forename">Wilhelm</span>: <span class="bookTitle">Cyprianus, Opera omnia (pars 2): Epistulae</span>, <span class="publicationPlace">Wien</span> 
+      <span class="publicationYear">1871</span> (<span class="publicationSeries">Corpus scriptorum ecclesiasticorum latinorum 3/2</span>).</p>
+   <p class="biblEntry">
+      <span class="surname">von Pflugk-Harttung</span>, <span class="forename">Julius</span>: <span class="bookTitle">Die Bullen der Päpste bis zum Ende des 12. Jahrhunderts</span>, <span class="publicationPlace">Gotha</span> 
+      <span class="publicationYear">1901</span>.</p>
+   <p class="biblEntry">
       <span class="surname">Vorwerk</span>, <span class="forename">Ursula</span> und <span class="forename">Werner</span> 
       <span class="surname"> Affeldt</span>: <span class="bookTitle">Frauen in Spätantike und Frühmittelalter</span>, <span class="publicationPlace">Sigmaringen</span> 
       <span class="publicationYear">1990</span>.</p>
@@ -4845,7 +4965,7 @@
       <span class="surname"> Nehlsen-von Stryk</span> und <span class="forename">Dieter</span> 
       <span class="surname"> Strauch</span> (Hgg.), <span class="bookTitle">Recht im frühmittelalterlichen Gallien</span>, <span class="publicationPlace">Köln u.a.</span> 
       <span class="publicationYear">1995</span>,  (<span class="publicationSeries">Rechtsgeschichtliche Schriften</span>), <span class="pubPages">S. 73–108</span>.</p>
-   <p class="biblEntry">
+   <p class="biblEntry" id="BL-W">
       <span class="surname">Wagner</span>, <span class="forename">Daniela</span> und <span class="forename">Hanna</span> 
       <span class="surname"> Wimmer</span>: <span class="bookTitle">Heilige: Bücher - Leiber - Orte: FS Bruno Reudenbach</span>, <span class="publicationPlace">Berlin</span> 
       <span class="publicationYear">2018</span>.</p>
@@ -5046,7 +5166,7 @@
       <span class="surname"> Jarnut</span> und <span class="forename">Walter</span> 
       <span class="surname"> Pohl</span> (Hgg.), <span class="bookTitle">Regna and gentes. The relationship between late antique and early medieval peoples and kingdoms in the transformation of the Roman world</span>, <span class="publicationPlace">Leiden</span> 
       <span class="publicationYear">2003</span>, <span class="pubPages">S. 21–53</span>.</p>
-   <p class="biblEntry">
+   <p class="biblEntry" id="BL-Z">
       <span class="surname">Zadora-Rio</span>, <span class="forename">Elisabeth</span>: <span class="articleTitle">The making of churchyards and parish territories in the early-medieval landscape of France and England in the 7th-12th centuries: a reconsideration</span>, in: <span class="bookTitle">Medieval archaeology 47</span> (<span class="publicationYear">2003</span>), <span class="pubPages">S. 1–19</span>.</p>
    <p class="biblEntry">
       <span class="surname">Zadora-Rio</span>, <span class="forename">Elisabeth</span>: <span class="articleTitle">Territoires paroissiaux et contrunction de l'espace vernaculaire</span>, in: <span class="bookTitle">Médiévales 49</span> (<span class="publicationYear">2005</span>), <span class="pubPages">S. 105–119</span>.</p>
@@ -5116,45 +5236,22 @@
       <span class="surname">Bihrer</span> (Hg.), <span class="bookTitle">Nova de Veteribus. Mittel- und neulateinische Studien für Paul Gerhard Schmidt</span>, <span class="publicationPlace">Leipzig</span> 
       <span class="publicationYear">2004</span>, <span class="pubPages">S. 180–191</span>.</p>
    <p class="biblEntry">
-      <span class="surname">van Dülmen</span>, <span class="forename">Richard</span>: <span class="bookTitle">Armut, Liebe, Ehre. Studien zur historischen Kulturforschung</span>, <span class="publicationPlace">Frankfurt am Main</span> 
-      <span class="publicationYear">1988</span>.</p>
-   <p class="biblEntry">
-      <span class="surname">van Goethem</span>, <span class="forename">Herman</span> und <span class="forename">Laurent L.</span> 
-      <span class="surname"> Waelkens</span>: <span class="bookTitle">Libertés, pluralisme et droit: Une approche historique. Actes du colloque d'Anvers, 27-30 mai 1993, Société d'histoire du droit</span>, <span class="publicationPlace">Bruxelles</span> 
-      <span class="publicationYear">1995</span>.</p>
-   <p class="biblEntry">
-      <span class="surname">von Campenhausen</span>, <span class="forename">Hans</span>: <span class="sectionTitle">Die Anfänge des Priesterbegriffs in der alten Kirche</span>, in: <span class="forename">Hans</span> 
-      <span class="surname">von Campenhausen</span> (Hg.), <span class="bookTitle">Tradition und Leben</span>, <span class="publicationPlace">Tübingen</span> 
-      <span class="publicationYear">1960</span>, <span class="pubPages">S. 272–289</span>.</p>
-   <p class="biblEntry">
-      <span class="surname">von Campenhausen</span>, <span class="forename">Hans</span>: <span class="bookTitle">Tradition und Leben</span>, <span class="publicationPlace">Tübingen</span> 
-      <span class="publicationYear">1960</span>.</p>
-   <p class="biblEntry">
-      <span class="surname">von Euw</span>, <span class="forename">Anton</span>, <span class="forename">Peter</span> 
-      <span class="surname"> Schreiner</span> und <span class="forename">Gudrun</span> 
-      <span class="surname"> Sporbeck</span>: <span class="bookTitle">Kaiserin Theophanu. Begegnung des Ostens und Westens um die Wende des ersten Jahrtausends. Gedenkschrift des Kölner Schnütgen-Museums zum 1000. Todesjahr der Kaiserin</span>, <span class="publicationPlace">Köln</span> 
-      <span class="publicationYear">1991</span>.</p>
-   <p class="biblEntry">
-      <span class="surname">von Hartel</span>, <span class="forename">Wilhelm</span>: <span class="bookTitle">Cyprianus, Opera omnia (pars 2): Epistulae</span>, <span class="publicationPlace">Wien</span> 
-      <span class="publicationYear">1871</span> (<span class="publicationSeries">Corpus scriptorum ecclesiasticorum latinorum 3/2</span>).</p>
-   <p class="biblEntry">
-      <span class="surname">von Pflugk-Harttung</span>, <span class="forename">Julius</span>: <span class="bookTitle">Die Bullen der Päpste bis zum Ende des 12. Jahrhunderts</span>, <span class="publicationPlace">Gotha</span> 
-      <span class="publicationYear">1901</span>.</p>
-   <p class="biblEntry">
       <span class="surname">zur Nieden</span>, <span class="forename">Andrea</span>: <span class="bookTitle">Der Alltag der Mönche: Studien zum Klosterplan von St. Gallen</span>, <span class="publicationPlace">Hamburg</span> 
       <span class="publicationYear">2008</span>.</p>
-   <p class="biblEntry">
-      <span class="bookTitle">Études d'histoire du droit privé dédiées à Pierre Petot</span>, <span class="publicationPlace">Paris</span> 
-      <span class="publicationYear">1959</span>.</p>
-   <p class="biblEntry">
-      <span class="bookTitle">Études d'histoire dédiées à la mémoire de Henri Pirenne par ses anciens élèves</span>, <span class="publicationPlace">Brüssel</span> 
-      <span class="publicationYear">1937</span>.</p>
-   <p class="biblEntry">
-      <span class="surname">Ó Carragáin</span>, <span class="forename">Tomás</span> und <span class="forename">Sam</span> 
-      <span class="surname"> Turner</span>: <span class="bookTitle">Making Christian landscapes in Atlantic Europe: conversion and consolidation in the early Middle Ages</span>, <span class="publicationPlace">Cork</span> 
-      <span class="publicationYear">2016</span>.</p>
 
 
     
 </div>
 {%endblock%}
+            {% block additionalscript %}
+        <script>
+        $(window).scroll(function(){
+            var navbarHeight = $('#mainNavbar').height();
+            var letterPos = $('#elex-letters').offset();
+            var bodyHeight = $('body').height();
+            $('#elex-letters').css('top', Math.min(Math.max(bodyHeight + navbarHeight - letterPos.top, 0), navbarHeight + 20));
+        });
+        </script>
+{% endblock %}  
+        
+    

--- a/templates/main/elex_collection.html
+++ b/templates/main/elex_collection.html
@@ -57,3 +57,15 @@
         </div>
     </div>
 {% endblock %}
+
+
+{% block additionalscript %}
+<script>
+$(window).scroll(function(){
+    var navbarHeight = $('#mainNavbar').height();
+    var letterPos = $('#elex-letters').offset();
+    var bodyHeight = $('body').height();
+    $('#elex-letters').css('top', Math.min(Math.max(bodyHeight + navbarHeight - letterPos.top, 0), navbarHeight + 20));
+});
+</script>
+{% endblock %}  

--- a/templates/main/sub_collection.html
+++ b/templates/main/sub_collection.html
@@ -37,18 +37,18 @@
                 {% set ns.appendix = 'yes' %}
                 <h5 class="mt-1">Appendix</h5>
             {% endif %}
-            <a type="button" class="btn btn-outline-primary px-1 mx-0" href="#N{{number}}">{{values['name']|replace('app', '')|int}}</a>
+            <a type="button" class="btn btn-outline-primary px-1 mx-0 corpus-nrs" href="#N{{number.replace('(', '').replace(')', '')}}">{{values['name']|replace('app', '')|int}}</a>
         {% endfor %}
     {% else %}
         {% for number, values in collections.readable.items() %}
-            <a type="button" class="btn btn-outline-primary px-1 mx-0" href="#N{{number}}">{% if 'lorsch' not in collections.current.id %}{{values['name']|replace('(', '')|replace(')', '')}}{% else %}{{values['name']}}{% endif %}</a>
+            <a type="button" class="btn btn-outline-primary px-1 mx-0 corpus-nrs" href="#N{{number.replace('(', '').replace(')', '')}}">{% if 'lorsch' not in collections.current.id %}{{values['name']|replace('(', '')|replace(')', '')}}{% else %}{{values['name']}}{% endif %}</a>
         {% endfor %}
     {% endif %}
     <div class="row">
         <div class="{{ 'col-xl-8 col-12' if collections.current.open_regesten or current_user.project_team else 'col-xl-4 col-12' }}">
             <ul class="list-group list-group-flush">
             {% for number, values in collections.readable.items() %}
-                <li id="N{{number}}" class="list-group-item flex-column">
+                <li id="N{{number.replace('(', '').replace(')', '')}}" class="list-group-item flex-column">
                     <div class="d-flex w-100 justify-content-between">
                         <h5>{{values['title']}}: </h5>
                         <span>


### PR DESCRIPTION
Also smoothed the navigation process in the corpus, lexicon, and bibliography screens so that the location navigated to is always visible instead of sometimes hidden under the main navbar