### PR TITLE
Styling changes

### DIFF
--- a/assets/css/theme.css
+++ b/assets/css/theme.css
@@ -218,7 +218,7 @@ nav .dropdown:hover .dropdown-menu, nav .dropup:hover .dropdown-menu {
 }
 
 .platzhalter {
-    font-weight: bold;
+  font-style: italic;
 }
 
 .lexicon {
@@ -1109,4 +1109,8 @@ p.short-regest {
     position: sticky;
     top: 100px;
     z-index: 900;
+}
+
+#capitula-table {
+    width: 60%;
 }

--- a/components/epidoc.xsl
+++ b/components/epidoc.xsl
@@ -189,6 +189,7 @@
     <xsl:template match="t:p">
         <xsl:element name="p">
             <xsl:if test="@style='subparagraph'"><xsl:attribute name="class">indented-paragraph</xsl:attribute></xsl:if>
+            <xsl:if test="@style='text-center'"><xsl:attribute name="class">text-center</xsl:attribute></xsl:if>
             <xsl:if test="@xml:id">
                 <xsl:attribute name="id">
                     <xsl:value-of select="@xml:id"/>
@@ -479,18 +480,25 @@
     <xsl:template match="t:table">
         <xsl:element name="table">
             <xsl:attribute name="class">table table-borderless table-sm</xsl:attribute>
+            <xsl:if test="@xml:id">
+                <xsl:attribute name="id">
+                    <xsl:value-of select="@xml:id"/>
+                </xsl:attribute>
+            </xsl:if>
             <xsl:apply-templates/>
         </xsl:element>
     </xsl:template>
     
     <xsl:template match="t:row">
         <xsl:element name="tr">
+            <xsl:if test="@style='text-center'"><xsl:attribute name="class">text-center</xsl:attribute></xsl:if>
             <xsl:apply-templates/>
         </xsl:element>
     </xsl:template>
     
     <xsl:template match="t:cell">
         <xsl:element name="td">
+            <xsl:if test="@cols"><xsl:attribute name="colspan"><xsl:value-of select="@cols"/></xsl:attribute></xsl:if>
             <xsl:call-template name="addWords"/>
         </xsl:element>
     </xsl:template>


### PR DESCRIPTION
- Tours Capitulatio table is now width 60%
- platzhalter in the formulae are now italic instead of bold
- epidoc XSLT should now deal better with more complex table (like Tour Capitulatio)