### PR TITLE
Changes per Jour fixe 26.10.2023

### DIFF
--- a/assets/css/theme.css
+++ b/assets/css/theme.css
@@ -1249,3 +1249,12 @@ img.disabled {
     width: 50%;
     padding: 0 0.5rem;
 }
+
+.charter-type-filter {
+    padding-top: 0px;
+    padding-bottom: 0px;
+}
+
+.part-collapse {
+    min-height: 18em;
+}

--- a/assets/js/empty.js
+++ b/assets/js/empty.js
@@ -948,4 +948,14 @@ $(document).ready(function () {
         var url = subdomain + '/texts/' + urns.join('+') + '/passage/' + sections.join('+');
         window.location.href = url;
     })
+
+    $('.charter-part-checkbox').click(function() {
+        parent_table = $( this ).closest('table');
+        target_button = $( 'button[data-target="' + parent_table.attr('id') + '"]' );
+        if ( parent_table.find('.charter-part-checkbox:checked').length > 0 ) {
+            target_button.removeAttr('disabled');
+        } else if ( parent_table.find('.charter-part-checkbox:checked').length == 0 ) {
+            target_button.attr('disabled', true);
+        }
+    })
 })

--- a/assets/js/empty.js
+++ b/assets/js/empty.js
@@ -490,90 +490,36 @@ $(document).ready(function () {
         ]
     });
 
-    var poenformelVordersatzTable = $('#Poenformel-Vordersatz-PartsTable').DataTable({
-        "autoWidth": true,
+    var tables = $('.parts-table').DataTable({
+        "autoWidth": false,
         "order": [],
+        "lengthMenu": [ [10, 25, 50, 100, -1], [10, 25, 50, 100, allResultsString] ],
         "language": {
             url: dataTableLangFile
         },
 //         "language": {
 //             "search": searchBoxString + ':'
 //         },
-        "columnDefs": [
-            {
-                "targets": [ "Poenformel-Vordersatz--all-charter-date-column" ],
-                "orderable": false
-            }
+        "columns": [
+            {"width": "15%"},
+            {"width": "10%", "orderable": false},
+            {"width": "10%", "orderable": false},
+            {"width": "65%"}
         ]
     });
 
-    var poenformelStrafklauselTable = $('#Poenformel-Strafklausel-PartsTable').DataTable({
-        "autoWidth": true,
-        "order": [],
-        "language": {
-            url: dataTableLangFile
-        },
-//         "language": {
-//             "search": searchBoxString + ':'
-//         },
-        "columnDefs": [
-            {
-                "targets": [ "Poenformel-Strafklausel--all-charter-date-column" ],
-                "orderable": false
-            }
-        ]
-    });
-
-    var stipulationsformelTable = $('#StipulationsformelPartsTable').DataTable({
-        "autoWidth": true,
-        "order": [],
-        "language": {
-            url: dataTableLangFile
-        },
-//         "language": {
-//             "search": searchBoxString + ':'
-//         },
-        "columnDefs": [
-            {
-                "targets": [ "Stipulationsformel-all-charter-date-column" ],
-                "orderable": false
-            }
-        ]
-    });
-
-    var ueberleitungsformelTable = $('#ÜberleitungsformelPartsTable').DataTable({
-        "autoWidth": true,
-        "order": [],
-        "language": {
-            url: dataTableLangFile
-        },
-//         "language": {
-//             "search": searchBoxString + ':'
-//         },
-        "columnDefs": [
-            {
-                "targets": [ "Überleitungsformel-all-charter-date-column" ],
-                "orderable": false
-            }
-        ]
-    });
-
-    var arengaTable = $('#ArengaPartsTable').DataTable({
-        "autoWidth": true,
-        "order": [],
-        "language": {
-            url: dataTableLangFile
-        },
-//         "language": {
-//             "search": searchBoxString + ':'
-//         },
-        "columnDefs": [
-            {
-                "targets": [ "Arenga-all-charter-date-column" ],
-                "orderable": false
-            }
-        ]
-    });
+    $('.charter-type-filter').click(function() {
+        var searchTerms = [];
+        clickedButton = $( this );
+        clickedButton.closest('form').find('.charter-type-filter:checked').each(function() {
+            searchTerms.push( $( this ).attr('value'))
+        })
+        if (searchTerms.length > 0) {
+            clickedButton.closest('table').DataTable().columns(2).search( searchTerms.join('|') , true, false).draw();
+        } else {
+            clickedButton.closest('table').DataTable().columns(2).search( '' ).draw();
+        }
+    })
 
     $('.search-regest-expand .regest-expand').click(function() {
         $( this ).parents('.search-regest-expand').find('.regest-no-expansion').toggleClass('d-none');

--- a/templates/main/all_parts_table.html
+++ b/templates/main/all_parts_table.html
@@ -6,14 +6,35 @@ e-Arenga">
                             <h4>Arengen</h4>
                             </button>
                         </h3>
-                        <div id="part-collapse-Arenga" class="collapse" aria-labelledby="part-category-Arenga" data-parent="#partAccordion">
+                        <div id="part-collapse-Arenga" class="collapse part-collapse" aria-labelledby="part-category-Arenga" data-parent="#partAccordion">
                             <div class="card-body">
-                                <table id="ArengaPartsTable" class="table table-sm table-hover table-bordered" aria-label="Arengen {{ _('Tabelle') }}">
+                                <table id="ArengaPartsTable" class="table table-sm table-hover table-bordered parts-table" aria-label="Arengen {{ _('Tabelle') }}">
                                     <thead>
                                         <tr>
                                             <th id="Arenga-title-charter-column" scope="col">{{ _('Urkunde') }}</th>
                                             <th id="Arenga-all-charter-date-column" scope="col">{{ _("Datum") }}</th>
-                                            <th id="Arenga-type-charter-column" scope="col">{{ _('Urkundenart') }}</th>
+                                            <th id="Arenga-type-charter-column" scope="col">
+                                                <div class="dropdown">
+                                                    <a class="dropdown-toggle text-body" href="#" role="button" data-toggle="dropdown" aria-expanded="false">{{ _('Urkundenart') }}</a>
+                                                    <form class="dropdown-menu px-4">
+                                                        <div class="form-group m-0">
+                                                            <input class="charter-type-filter form-check-input" id="Arenga-kauf-checkbox" type="checkbox" value="Kauf"><label class="form-check-label font-weight-normal" for="Arenga-kauf-checkbox">Kauf</a>
+                                                        </div>
+                                                        <div class="form-group m-0">
+                                                            <input class="charter-type-filter form-check-input" id="Arenga-praestarie-checkbox" type="checkbox" value="Prästarie"><label class="form-check-label font-weight-normal" for="Arenga-praestarie-checkbox">Prästarie</a>
+                                                        </div>
+                                                        <div class="form-group m-0">
+                                                            <input class="charter-type-filter form-check-input" id="Arenga-prekarie-checkbox" type="checkbox" value="Prekarie"><label class="form-check-label font-weight-normal" for="Arenga-prekarie-checkbox">Prekarie</a>
+                                                        </div>
+                                                        <div class="form-group m-0">
+                                                            <input class="charter-type-filter form-check-input" id="Arenga-schenkung-checkbox" type="checkbox" value="Schenkung"><label class="form-check-label font-weight-normal" for="Arenga-schenkung-checkbox">Schenkung</a>
+                                                        </div>
+                                                        <div class="form-group m-0">
+                                                            <input class="charter-type-filter form-check-input" id="Arenga-tausch-checkbox" type="checkbox" value="Tausch"><label class="form-check-label font-weight-normal" for="Arenga-tausch-checkbox">Tausch</a>
+                                                        </div>
+                                                    </form>
+                                                </div>
+                                            </th>
                                             <th id="Arenga-charter-column" scope="col">Arenga</th>
                                         </tr>
                                     </thead>
@@ -1945,14 +1966,35 @@ e-Poenformel-Vordersatz-">
                             <h4>Poenformel (Vordersatz)</h4>
                             </button>
                         </h3>
-                        <div id="part-collapse-Poenformel-Vordersatz-" class="collapse" aria-labelledby="part-category-Poenformel-Vordersatz-" data-parent="#partAccordion">
+                        <div id="part-collapse-Poenformel-Vordersatz-" class="collapse part-collapse" aria-labelledby="part-category-Poenformel-Vordersatz-" data-parent="#partAccordion">
                             <div class="card-body">
-                                <table id="Poenformel-Vordersatz-PartsTable" class="table table-sm table-hover table-bordered" aria-label="Poenformel (Vordersatz) {{ _('Tabelle') }}">
+                                <table id="Poenformel-Vordersatz-PartsTable" class="table table-sm table-hover table-bordered parts-table" aria-label="Poenformel (Vordersatz) {{ _('Tabelle') }}">
                                     <thead>
                                         <tr>
                                             <th id="Poenformel-Vordersatz--title-charter-column" scope="col">{{ _('Urkunde') }}</th>
                                             <th id="Poenformel-Vordersatz--all-charter-date-column" scope="col">{{ _("Datum") }}</th>
-                                            <th id="Poenformel-Vordersatz--type-charter-column" scope="col">{{ _('Urkundenart') }}</th>
+                                            <th id="Poenformel-Vordersatz--type-charter-column" scope="col">
+                                                <div class="dropdown">
+                                                    <a class="dropdown-toggle text-body" href="#" role="button" data-toggle="dropdown" aria-expanded="false">{{ _('Urkundenart') }}</a>
+                                                    <form class="dropdown-menu px-4">
+                                                        <div class="form-group m-0">
+                                                            <input class="charter-type-filter form-check-input" id="Poenformel-Vordersatz--kauf-checkbox" type="checkbox" value="Kauf"><label class="form-check-label font-weight-normal" for="Poenformel-Vordersatz--kauf-checkbox">Kauf</a>
+                                                        </div>
+                                                        <div class="form-group m-0">
+                                                            <input class="charter-type-filter form-check-input" id="Poenformel-Vordersatz--praestarie-checkbox" type="checkbox" value="Prästarie"><label class="form-check-label font-weight-normal" for="Poenformel-Vordersatz--praestarie-checkbox">Prästarie</a>
+                                                        </div>
+                                                        <div class="form-group m-0">
+                                                            <input class="charter-type-filter form-check-input" id="Poenformel-Vordersatz--prekarie-checkbox" type="checkbox" value="Prekarie"><label class="form-check-label font-weight-normal" for="Poenformel-Vordersatz--prekarie-checkbox">Prekarie</a>
+                                                        </div>
+                                                        <div class="form-group m-0">
+                                                            <input class="charter-type-filter form-check-input" id="Poenformel-Vordersatz--schenkung-checkbox" type="checkbox" value="Schenkung"><label class="form-check-label font-weight-normal" for="Poenformel-Vordersatz--schenkung-checkbox">Schenkung</a>
+                                                        </div>
+                                                        <div class="form-group m-0">
+                                                            <input class="charter-type-filter form-check-input" id="Poenformel-Vordersatz--tausch-checkbox" type="checkbox" value="Tausch"><label class="form-check-label font-weight-normal" for="Poenformel-Vordersatz--tausch-checkbox">Tausch</a>
+                                                        </div>
+                                                    </form>
+                                                </div>
+                                            </th>
                                             <th id="Poenformel-Vordersatz--charter-column" scope="col">Poenformel (Vordersatz)</th>
                                         </tr>
                                     </thead>
@@ -6633,14 +6675,35 @@ e-Poenformel-Strafklausel-">
                             <h4>Poenformel (Strafklausel)</h4>
                             </button>
                         </h3>
-                        <div id="part-collapse-Poenformel-Strafklausel-" class="collapse" aria-labelledby="part-category-Poenformel-Strafklausel-" data-parent="#partAccordion">
+                        <div id="part-collapse-Poenformel-Strafklausel-" class="collapse part-collapse" aria-labelledby="part-category-Poenformel-Strafklausel-" data-parent="#partAccordion">
                             <div class="card-body">
-                                <table id="Poenformel-Strafklausel-PartsTable" class="table table-sm table-hover table-bordered" aria-label="Poenformel (Strafklausel) {{ _('Tabelle') }}">
+                                <table id="Poenformel-Strafklausel-PartsTable" class="table table-sm table-hover table-bordered parts-table" aria-label="Poenformel (Strafklausel) {{ _('Tabelle') }}">
                                     <thead>
                                         <tr>
                                             <th id="Poenformel-Strafklausel--title-charter-column" scope="col">{{ _('Urkunde') }}</th>
                                             <th id="Poenformel-Strafklausel--all-charter-date-column" scope="col">{{ _("Datum") }}</th>
-                                            <th id="Poenformel-Strafklausel--type-charter-column" scope="col">{{ _('Urkundenart') }}</th>
+                                            <th id="Poenformel-Strafklausel--type-charter-column" scope="col">
+                                                <div class="dropdown">
+                                                    <a class="dropdown-toggle text-body" href="#" role="button" data-toggle="dropdown" aria-expanded="false">{{ _('Urkundenart') }}</a>
+                                                    <form class="dropdown-menu px-4">
+                                                        <div class="form-group m-0">
+                                                            <input class="charter-type-filter form-check-input" id="Poenformel-Strafklausel--kauf-checkbox" type="checkbox" value="Kauf"><label class="form-check-label font-weight-normal" for="Poenformel-Strafklausel--kauf-checkbox">Kauf</a>
+                                                        </div>
+                                                        <div class="form-group m-0">
+                                                            <input class="charter-type-filter form-check-input" id="Poenformel-Strafklausel--praestarie-checkbox" type="checkbox" value="Prästarie"><label class="form-check-label font-weight-normal" for="Poenformel-Strafklausel--praestarie-checkbox">Prästarie</a>
+                                                        </div>
+                                                        <div class="form-group m-0">
+                                                            <input class="charter-type-filter form-check-input" id="Poenformel-Strafklausel--prekarie-checkbox" type="checkbox" value="Prekarie"><label class="form-check-label font-weight-normal" for="Poenformel-Strafklausel--prekarie-checkbox">Prekarie</a>
+                                                        </div>
+                                                        <div class="form-group m-0">
+                                                            <input class="charter-type-filter form-check-input" id="Poenformel-Strafklausel--schenkung-checkbox" type="checkbox" value="Schenkung"><label class="form-check-label font-weight-normal" for="Poenformel-Strafklausel--schenkung-checkbox">Schenkung</a>
+                                                        </div>
+                                                        <div class="form-group m-0">
+                                                            <input class="charter-type-filter form-check-input" id="Poenformel-Strafklausel--tausch-checkbox" type="checkbox" value="Tausch"><label class="form-check-label font-weight-normal" for="Poenformel-Strafklausel--tausch-checkbox">Tausch</a>
+                                                        </div>
+                                                    </form>
+                                                </div>
+                                            </th>
                                             <th id="Poenformel-Strafklausel--charter-column" scope="col">Poenformel (Strafklausel)</th>
                                         </tr>
                                     </thead>
@@ -9893,14 +9956,35 @@ e-Stipulationsformel">
                             <h4>Stipulationsformel</h4>
                             </button>
                         </h3>
-                        <div id="part-collapse-Stipulationsformel" class="collapse" aria-labelledby="part-category-Stipulationsformel" data-parent="#partAccordion">
+                        <div id="part-collapse-Stipulationsformel" class="collapse part-collapse" aria-labelledby="part-category-Stipulationsformel" data-parent="#partAccordion">
                             <div class="card-body">
-                                <table id="StipulationsformelPartsTable" class="table table-sm table-hover table-bordered" aria-label="Stipulationsformel {{ _('Tabelle') }}">
+                                <table id="StipulationsformelPartsTable" class="table table-sm table-hover table-bordered parts-table" aria-label="Stipulationsformel {{ _('Tabelle') }}">
                                     <thead>
                                         <tr>
                                             <th id="Stipulationsformel-title-charter-column" scope="col">{{ _('Urkunde') }}</th>
                                             <th id="Stipulationsformel-all-charter-date-column" scope="col">{{ _("Datum") }}</th>
-                                            <th id="Stipulationsformel-type-charter-column" scope="col">{{ _('Urkundenart') }}</th>
+                                            <th id="Stipulationsformel-type-charter-column" scope="col">
+                                                <div class="dropdown">
+                                                    <a class="dropdown-toggle text-body" href="#" role="button" data-toggle="dropdown" aria-expanded="false">{{ _('Urkundenart') }}</a>
+                                                    <form class="dropdown-menu px-4">
+                                                        <div class="form-group m-0">
+                                                            <input class="charter-type-filter form-check-input" id="Stipulationsformel-kauf-checkbox" type="checkbox" value="Kauf"><label class="form-check-label font-weight-normal" for="Stipulationsformel-kauf-checkbox">Kauf</a>
+                                                        </div>
+                                                        <div class="form-group m-0">
+                                                            <input class="charter-type-filter form-check-input" id="Stipulationsformel-praestarie-checkbox" type="checkbox" value="Prästarie"><label class="form-check-label font-weight-normal" for="Stipulationsformel-praestarie-checkbox">Prästarie</a>
+                                                        </div>
+                                                        <div class="form-group m-0">
+                                                            <input class="charter-type-filter form-check-input" id="Stipulationsformel-prekarie-checkbox" type="checkbox" value="Prekarie"><label class="form-check-label font-weight-normal" for="Stipulationsformel-prekarie-checkbox">Prekarie</a>
+                                                        </div>
+                                                        <div class="form-group m-0">
+                                                            <input class="charter-type-filter form-check-input" id="Stipulationsformel-schenkung-checkbox" type="checkbox" value="Schenkung"><label class="form-check-label font-weight-normal" for="Stipulationsformel-schenkung-checkbox">Schenkung</a>
+                                                        </div>
+                                                        <div class="form-group m-0">
+                                                            <input class="charter-type-filter form-check-input" id="Stipulationsformel-tausch-checkbox" type="checkbox" value="Tausch"><label class="form-check-label font-weight-normal" for="Stipulationsformel-tausch-checkbox">Tausch</a>
+                                                        </div>
+                                                    </form>
+                                                </div>
+                                            </th>
                                             <th id="Stipulationsformel-charter-column" scope="col">Stipulationsformel</th>
                                         </tr>
                                     </thead>
@@ -15038,14 +15122,35 @@ e-Überleitungsformel">
                             <h4>Überleitungsformel</h4>
                             </button>
                         </h3>
-                        <div id="part-collapse-Überleitungsformel" class="collapse" aria-labelledby="part-category-Überleitungsformel" data-parent="#partAccordion">
+                        <div id="part-collapse-Überleitungsformel" class="collapse part-collapse" aria-labelledby="part-category-Überleitungsformel" data-parent="#partAccordion">
                             <div class="card-body">
-                                <table id="ÜberleitungsformelPartsTable" class="table table-sm table-hover table-bordered" aria-label="Überleitungsformel {{ _('Tabelle') }}">
+                                <table id="ÜberleitungsformelPartsTable" class="table table-sm table-hover table-bordered parts-table" aria-label="Überleitungsformel {{ _('Tabelle') }}">
                                     <thead>
                                         <tr>
                                             <th id="Überleitungsformel-title-charter-column" scope="col">{{ _('Urkunde') }}</th>
                                             <th id="Überleitungsformel-all-charter-date-column" scope="col">{{ _("Datum") }}</th>
-                                            <th id="Überleitungsformel-type-charter-column" scope="col">{{ _('Urkundenart') }}</th>
+                                            <th id="Überleitungsformel-type-charter-column" scope="col">
+                                                <div class="dropdown">
+                                                    <a class="dropdown-toggle text-body" href="#" role="button" data-toggle="dropdown" aria-expanded="false">{{ _('Urkundenart') }}</a>
+                                                    <form class="dropdown-menu px-4">
+                                                        <div class="form-group m-0">
+                                                            <input class="charter-type-filter form-check-input" id="Überleitungsformel-kauf-checkbox" type="checkbox" value="Kauf"><label class="form-check-label font-weight-normal" for="Überleitungsformel-kauf-checkbox">Kauf</a>
+                                                        </div>
+                                                        <div class="form-group m-0">
+                                                            <input class="charter-type-filter form-check-input" id="Überleitungsformel-praestarie-checkbox" type="checkbox" value="Prästarie"><label class="form-check-label font-weight-normal" for="Überleitungsformel-praestarie-checkbox">Prästarie</a>
+                                                        </div>
+                                                        <div class="form-group m-0">
+                                                            <input class="charter-type-filter form-check-input" id="Überleitungsformel-prekarie-checkbox" type="checkbox" value="Prekarie"><label class="form-check-label font-weight-normal" for="Überleitungsformel-prekarie-checkbox">Prekarie</a>
+                                                        </div>
+                                                        <div class="form-group m-0">
+                                                            <input class="charter-type-filter form-check-input" id="Überleitungsformel-schenkung-checkbox" type="checkbox" value="Schenkung"><label class="form-check-label font-weight-normal" for="Überleitungsformel-schenkung-checkbox">Schenkung</a>
+                                                        </div>
+                                                        <div class="form-group m-0">
+                                                            <input class="charter-type-filter form-check-input" id="Überleitungsformel-tausch-checkbox" type="checkbox" value="Tausch"><label class="form-check-label font-weight-normal" for="Überleitungsformel-tausch-checkbox">Tausch</a>
+                                                        </div>
+                                                    </form>
+                                                </div>
+                                            </th>
                                             <th id="Überleitungsformel-charter-column" scope="col">Überleitungsformel</th>
                                         </tr>
                                     </thead>

--- a/templates/main/charter_group_table.html
+++ b/templates/main/charter_group_table.html
@@ -7,14 +7,14 @@
                         </h3>
                         <div class="accordion collapse" id="Mondseer_FormenCharterGroupAccordion">
                         
-                                <h3 class="card-header" id="part-allCharterGroups-I">
-                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-I" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-I">
+                                <h3 class="card-header" id="part-allCharterGroups-Mondseer_FormenI">
+                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-Mondseer_FormenI" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-Mondseer_FormenI">
                                     <h5>{{ _("Gruppe") }} I</h5>
                                     </button>
                                 </h3>
-                                <div id="part-collapse-allCharterGroups-I" class="collapse" aria-labelledby="allCharterGroupTableI" data-parent="#Mondseer_FormenCharterGroupAccordion">
+                                <div id="part-collapse-allCharterGroups-Mondseer_FormenI" class="collapse" aria-labelledby="allCharterGroupTableMondseer_FormenI" data-parent="#Mondseer_FormenCharterGroupAccordion">
                                     <div class="card-body">
-                                        <table id="allCharterGroupTableI" class="table table-sm table-hover table-bordered" aria-label="{{ _('Gesamte Urkundengruppe') }} {{ _("Gruppe") }} I">
+                                        <table id="allCharterGroupTableMondseer_FormenI" class="table table-sm table-hover table-bordered" aria-label="{{ _("Tabelle") }}: Mondseer Formen  {{ _("Gruppe") }} I">
                                             <thead>
                                                 <tr>
                                                     <th id="all-charter-checkbox-column" scope="col"></th>
@@ -66,17 +66,17 @@
                                         </tr>
                                             </tbody>
                                         </table>
-                                        <button data-target="allCharterGroupTableI" class="btn btn-primary charter-select-button" type="button" aria-expanded="true">{{ _('Gewählte Urkunken lesen') }}</button>
+                                        <button data-target="allCharterGroupTableMondseer_FormenI" class="btn btn-primary charter-select-button" type="button" aria-expanded="true" disabled>{{ _('Gewählte Urkunken lesen') }}</button>
                                     </div>
                                 </div>
-                                <h3 class="card-header" id="part-allCharterGroups-II">
-                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-II" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-II">
+                                <h3 class="card-header" id="part-allCharterGroups-Mondseer_FormenII">
+                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-Mondseer_FormenII" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-Mondseer_FormenII">
                                     <h5>{{ _("Gruppe") }} II</h5>
                                     </button>
                                 </h3>
-                                <div id="part-collapse-allCharterGroups-II" class="collapse" aria-labelledby="allCharterGroupTableII" data-parent="#Mondseer_FormenCharterGroupAccordion">
+                                <div id="part-collapse-allCharterGroups-Mondseer_FormenII" class="collapse" aria-labelledby="allCharterGroupTableMondseer_FormenII" data-parent="#Mondseer_FormenCharterGroupAccordion">
                                     <div class="card-body">
-                                        <table id="allCharterGroupTableII" class="table table-sm table-hover table-bordered" aria-label="{{ _('Gesamte Urkundengruppe') }} {{ _("Gruppe") }} II">
+                                        <table id="allCharterGroupTableMondseer_FormenII" class="table table-sm table-hover table-bordered" aria-label="{{ _("Tabelle") }}: Mondseer Formen  {{ _("Gruppe") }} II">
                                             <thead>
                                                 <tr>
                                                     <th id="all-charter-checkbox-column" scope="col"></th>
@@ -128,17 +128,17 @@
                                         </tr>
                                             </tbody>
                                         </table>
-                                        <button data-target="allCharterGroupTableII" class="btn btn-primary charter-select-button" type="button" aria-expanded="true">{{ _('Gewählte Urkunken lesen') }}</button>
+                                        <button data-target="allCharterGroupTableMondseer_FormenII" class="btn btn-primary charter-select-button" type="button" aria-expanded="true" disabled>{{ _('Gewählte Urkunken lesen') }}</button>
                                     </div>
                                 </div>
-                                <h3 class="card-header" id="part-allCharterGroups-IIIa">
-                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-IIIa" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-IIIa">
+                                <h3 class="card-header" id="part-allCharterGroups-Mondseer_FormenIIIa">
+                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-Mondseer_FormenIIIa" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-Mondseer_FormenIIIa">
                                     <h5>{{ _("Gruppe") }} IIIa</h5>
                                     </button>
                                 </h3>
-                                <div id="part-collapse-allCharterGroups-IIIa" class="collapse" aria-labelledby="allCharterGroupTableIIIa" data-parent="#Mondseer_FormenCharterGroupAccordion">
+                                <div id="part-collapse-allCharterGroups-Mondseer_FormenIIIa" class="collapse" aria-labelledby="allCharterGroupTableMondseer_FormenIIIa" data-parent="#Mondseer_FormenCharterGroupAccordion">
                                     <div class="card-body">
-                                        <table id="allCharterGroupTableIIIa" class="table table-sm table-hover table-bordered" aria-label="{{ _('Gesamte Urkundengruppe') }} {{ _("Gruppe") }} IIIa">
+                                        <table id="allCharterGroupTableMondseer_FormenIIIa" class="table table-sm table-hover table-bordered" aria-label="{{ _("Tabelle") }}: Mondseer Formen  {{ _("Gruppe") }} IIIa">
                                             <thead>
                                                 <tr>
                                                     <th id="all-charter-checkbox-column" scope="col"></th>
@@ -170,17 +170,17 @@
                                         </tr>
                                             </tbody>
                                         </table>
-                                        <button data-target="allCharterGroupTableIIIa" class="btn btn-primary charter-select-button" type="button" aria-expanded="true">{{ _('Gewählte Urkunken lesen') }}</button>
+                                        <button data-target="allCharterGroupTableMondseer_FormenIIIa" class="btn btn-primary charter-select-button" type="button" aria-expanded="true" disabled>{{ _('Gewählte Urkunken lesen') }}</button>
                                     </div>
                                 </div>
-                                <h3 class="card-header" id="part-allCharterGroups-IIIb">
-                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-IIIb" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-IIIb">
+                                <h3 class="card-header" id="part-allCharterGroups-Mondseer_FormenIIIb">
+                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-Mondseer_FormenIIIb" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-Mondseer_FormenIIIb">
                                     <h5>{{ _("Gruppe") }} IIIb</h5>
                                     </button>
                                 </h3>
-                                <div id="part-collapse-allCharterGroups-IIIb" class="collapse" aria-labelledby="allCharterGroupTableIIIb" data-parent="#Mondseer_FormenCharterGroupAccordion">
+                                <div id="part-collapse-allCharterGroups-Mondseer_FormenIIIb" class="collapse" aria-labelledby="allCharterGroupTableMondseer_FormenIIIb" data-parent="#Mondseer_FormenCharterGroupAccordion">
                                     <div class="card-body">
-                                        <table id="allCharterGroupTableIIIb" class="table table-sm table-hover table-bordered" aria-label="{{ _('Gesamte Urkundengruppe') }} {{ _("Gruppe") }} IIIb">
+                                        <table id="allCharterGroupTableMondseer_FormenIIIb" class="table table-sm table-hover table-bordered" aria-label="{{ _("Tabelle") }}: Mondseer Formen  {{ _("Gruppe") }} IIIb">
                                             <thead>
                                                 <tr>
                                                     <th id="all-charter-checkbox-column" scope="col"></th>
@@ -207,17 +207,17 @@
                                         </tr>
                                             </tbody>
                                         </table>
-                                        <button data-target="allCharterGroupTableIIIb" class="btn btn-primary charter-select-button" type="button" aria-expanded="true">{{ _('Gewählte Urkunken lesen') }}</button>
+                                        <button data-target="allCharterGroupTableMondseer_FormenIIIb" class="btn btn-primary charter-select-button" type="button" aria-expanded="true" disabled>{{ _('Gewählte Urkunken lesen') }}</button>
                                     </div>
                                 </div>
-                                <h3 class="card-header" id="part-allCharterGroups-IIIc">
-                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-IIIc" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-IIIc">
+                                <h3 class="card-header" id="part-allCharterGroups-Mondseer_FormenIIIc">
+                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-Mondseer_FormenIIIc" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-Mondseer_FormenIIIc">
                                     <h5>{{ _("Gruppe") }} IIIc</h5>
                                     </button>
                                 </h3>
-                                <div id="part-collapse-allCharterGroups-IIIc" class="collapse" aria-labelledby="allCharterGroupTableIIIc" data-parent="#Mondseer_FormenCharterGroupAccordion">
+                                <div id="part-collapse-allCharterGroups-Mondseer_FormenIIIc" class="collapse" aria-labelledby="allCharterGroupTableMondseer_FormenIIIc" data-parent="#Mondseer_FormenCharterGroupAccordion">
                                     <div class="card-body">
-                                        <table id="allCharterGroupTableIIIc" class="table table-sm table-hover table-bordered" aria-label="{{ _('Gesamte Urkundengruppe') }} {{ _("Gruppe") }} IIIc">
+                                        <table id="allCharterGroupTableMondseer_FormenIIIc" class="table table-sm table-hover table-bordered" aria-label="{{ _("Tabelle") }}: Mondseer Formen  {{ _("Gruppe") }} IIIc">
                                             <thead>
                                                 <tr>
                                                     <th id="all-charter-checkbox-column" scope="col"></th>
@@ -244,17 +244,17 @@
                                         </tr>
                                             </tbody>
                                         </table>
-                                        <button data-target="allCharterGroupTableIIIc" class="btn btn-primary charter-select-button" type="button" aria-expanded="true">{{ _('Gewählte Urkunken lesen') }}</button>
+                                        <button data-target="allCharterGroupTableMondseer_FormenIIIc" class="btn btn-primary charter-select-button" type="button" aria-expanded="true" disabled>{{ _('Gewählte Urkunken lesen') }}</button>
                                     </div>
                                 </div>
-                                <h3 class="card-header" id="part-allCharterGroups-IV">
-                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-IV" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-IV">
+                                <h3 class="card-header" id="part-allCharterGroups-Mondseer_FormenIV">
+                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-Mondseer_FormenIV" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-Mondseer_FormenIV">
                                     <h5>{{ _("Gruppe") }} IV</h5>
                                     </button>
                                 </h3>
-                                <div id="part-collapse-allCharterGroups-IV" class="collapse" aria-labelledby="allCharterGroupTableIV" data-parent="#Mondseer_FormenCharterGroupAccordion">
+                                <div id="part-collapse-allCharterGroups-Mondseer_FormenIV" class="collapse" aria-labelledby="allCharterGroupTableMondseer_FormenIV" data-parent="#Mondseer_FormenCharterGroupAccordion">
                                     <div class="card-body">
-                                        <table id="allCharterGroupTableIV" class="table table-sm table-hover table-bordered" aria-label="{{ _('Gesamte Urkundengruppe') }} {{ _("Gruppe") }} IV">
+                                        <table id="allCharterGroupTableMondseer_FormenIV" class="table table-sm table-hover table-bordered" aria-label="{{ _("Tabelle") }}: Mondseer Formen  {{ _("Gruppe") }} IV">
                                             <thead>
                                                 <tr>
                                                     <th id="all-charter-checkbox-column" scope="col"></th>
@@ -341,17 +341,17 @@
                                         </tr>
                                             </tbody>
                                         </table>
-                                        <button data-target="allCharterGroupTableIV" class="btn btn-primary charter-select-button" type="button" aria-expanded="true">{{ _('Gewählte Urkunken lesen') }}</button>
+                                        <button data-target="allCharterGroupTableMondseer_FormenIV" class="btn btn-primary charter-select-button" type="button" aria-expanded="true" disabled>{{ _('Gewählte Urkunken lesen') }}</button>
                                     </div>
                                 </div>
-                                <h3 class="card-header" id="part-allCharterGroups-Va">
-                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-Va" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-Va">
+                                <h3 class="card-header" id="part-allCharterGroups-Mondseer_FormenVa">
+                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-Mondseer_FormenVa" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-Mondseer_FormenVa">
                                     <h5>{{ _("Gruppe") }} Va</h5>
                                     </button>
                                 </h3>
-                                <div id="part-collapse-allCharterGroups-Va" class="collapse" aria-labelledby="allCharterGroupTableVa" data-parent="#Mondseer_FormenCharterGroupAccordion">
+                                <div id="part-collapse-allCharterGroups-Mondseer_FormenVa" class="collapse" aria-labelledby="allCharterGroupTableMondseer_FormenVa" data-parent="#Mondseer_FormenCharterGroupAccordion">
                                     <div class="card-body">
-                                        <table id="allCharterGroupTableVa" class="table table-sm table-hover table-bordered" aria-label="{{ _('Gesamte Urkundengruppe') }} {{ _("Gruppe") }} Va">
+                                        <table id="allCharterGroupTableMondseer_FormenVa" class="table table-sm table-hover table-bordered" aria-label="{{ _("Tabelle") }}: Mondseer Formen  {{ _("Gruppe") }} Va">
                                             <thead>
                                                 <tr>
                                                     <th id="all-charter-checkbox-column" scope="col"></th>
@@ -423,17 +423,17 @@
                                         </tr>
                                             </tbody>
                                         </table>
-                                        <button data-target="allCharterGroupTableVa" class="btn btn-primary charter-select-button" type="button" aria-expanded="true">{{ _('Gewählte Urkunken lesen') }}</button>
+                                        <button data-target="allCharterGroupTableMondseer_FormenVa" class="btn btn-primary charter-select-button" type="button" aria-expanded="true" disabled>{{ _('Gewählte Urkunken lesen') }}</button>
                                     </div>
                                 </div>
-                                <h3 class="card-header" id="part-allCharterGroups-Vb">
-                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-Vb" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-Vb">
+                                <h3 class="card-header" id="part-allCharterGroups-Mondseer_FormenVb">
+                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-Mondseer_FormenVb" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-Mondseer_FormenVb">
                                     <h5>{{ _("Gruppe") }} Vb</h5>
                                     </button>
                                 </h3>
-                                <div id="part-collapse-allCharterGroups-Vb" class="collapse" aria-labelledby="allCharterGroupTableVb" data-parent="#Mondseer_FormenCharterGroupAccordion">
+                                <div id="part-collapse-allCharterGroups-Mondseer_FormenVb" class="collapse" aria-labelledby="allCharterGroupTableMondseer_FormenVb" data-parent="#Mondseer_FormenCharterGroupAccordion">
                                     <div class="card-body">
-                                        <table id="allCharterGroupTableVb" class="table table-sm table-hover table-bordered" aria-label="{{ _('Gesamte Urkundengruppe') }} {{ _("Gruppe") }} Vb">
+                                        <table id="allCharterGroupTableMondseer_FormenVb" class="table table-sm table-hover table-bordered" aria-label="{{ _("Tabelle") }}: Mondseer Formen  {{ _("Gruppe") }} Vb">
                                             <thead>
                                                 <tr>
                                                     <th id="all-charter-checkbox-column" scope="col"></th>
@@ -475,17 +475,17 @@
                                         </tr>
                                             </tbody>
                                         </table>
-                                        <button data-target="allCharterGroupTableVb" class="btn btn-primary charter-select-button" type="button" aria-expanded="true">{{ _('Gewählte Urkunken lesen') }}</button>
+                                        <button data-target="allCharterGroupTableMondseer_FormenVb" class="btn btn-primary charter-select-button" type="button" aria-expanded="true" disabled>{{ _('Gewählte Urkunken lesen') }}</button>
                                     </div>
                                 </div>
-                                <h3 class="card-header" id="part-allCharterGroups-VI">
-                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-VI" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-VI">
+                                <h3 class="card-header" id="part-allCharterGroups-Mondseer_FormenVI">
+                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-Mondseer_FormenVI" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-Mondseer_FormenVI">
                                     <h5>{{ _("Gruppe") }} VI</h5>
                                     </button>
                                 </h3>
-                                <div id="part-collapse-allCharterGroups-VI" class="collapse" aria-labelledby="allCharterGroupTableVI" data-parent="#Mondseer_FormenCharterGroupAccordion">
+                                <div id="part-collapse-allCharterGroups-Mondseer_FormenVI" class="collapse" aria-labelledby="allCharterGroupTableMondseer_FormenVI" data-parent="#Mondseer_FormenCharterGroupAccordion">
                                     <div class="card-body">
-                                        <table id="allCharterGroupTableVI" class="table table-sm table-hover table-bordered" aria-label="{{ _('Gesamte Urkundengruppe') }} {{ _("Gruppe") }} VI">
+                                        <table id="allCharterGroupTableMondseer_FormenVI" class="table table-sm table-hover table-bordered" aria-label="{{ _("Tabelle") }}: Mondseer Formen  {{ _("Gruppe") }} VI">
                                             <thead>
                                                 <tr>
                                                     <th id="all-charter-checkbox-column" scope="col"></th>
@@ -507,17 +507,17 @@
                                         </tr>
                                             </tbody>
                                         </table>
-                                        <button data-target="allCharterGroupTableVI" class="btn btn-primary charter-select-button" type="button" aria-expanded="true">{{ _('Gewählte Urkunken lesen') }}</button>
+                                        <button data-target="allCharterGroupTableMondseer_FormenVI" class="btn btn-primary charter-select-button" type="button" aria-expanded="true" disabled>{{ _('Gewählte Urkunken lesen') }}</button>
                                     </div>
                                 </div>
-                                <h3 class="card-header" id="part-allCharterGroups-VII">
-                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-VII" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-VII">
+                                <h3 class="card-header" id="part-allCharterGroups-Mondseer_FormenVII">
+                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-Mondseer_FormenVII" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-Mondseer_FormenVII">
                                     <h5>{{ _("Gruppe") }} VII</h5>
                                     </button>
                                 </h3>
-                                <div id="part-collapse-allCharterGroups-VII" class="collapse" aria-labelledby="allCharterGroupTableVII" data-parent="#Mondseer_FormenCharterGroupAccordion">
+                                <div id="part-collapse-allCharterGroups-Mondseer_FormenVII" class="collapse" aria-labelledby="allCharterGroupTableMondseer_FormenVII" data-parent="#Mondseer_FormenCharterGroupAccordion">
                                     <div class="card-body">
-                                        <table id="allCharterGroupTableVII" class="table table-sm table-hover table-bordered" aria-label="{{ _('Gesamte Urkundengruppe') }} {{ _("Gruppe") }} VII">
+                                        <table id="allCharterGroupTableMondseer_FormenVII" class="table table-sm table-hover table-bordered" aria-label="{{ _("Tabelle") }}: Mondseer Formen  {{ _("Gruppe") }} VII">
                                             <thead>
                                                 <tr>
                                                     <th id="all-charter-checkbox-column" scope="col"></th>
@@ -564,17 +564,17 @@
                                         </tr>
                                             </tbody>
                                         </table>
-                                        <button data-target="allCharterGroupTableVII" class="btn btn-primary charter-select-button" type="button" aria-expanded="true">{{ _('Gewählte Urkunken lesen') }}</button>
+                                        <button data-target="allCharterGroupTableMondseer_FormenVII" class="btn btn-primary charter-select-button" type="button" aria-expanded="true" disabled>{{ _('Gewählte Urkunken lesen') }}</button>
                                     </div>
                                 </div>
-                                <h3 class="card-header" id="part-allCharterGroups-VIII">
-                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-VIII" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-VIII">
+                                <h3 class="card-header" id="part-allCharterGroups-Mondseer_FormenVIII">
+                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-Mondseer_FormenVIII" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-Mondseer_FormenVIII">
                                     <h5>{{ _("Gruppe") }} VIII</h5>
                                     </button>
                                 </h3>
-                                <div id="part-collapse-allCharterGroups-VIII" class="collapse" aria-labelledby="allCharterGroupTableVIII" data-parent="#Mondseer_FormenCharterGroupAccordion">
+                                <div id="part-collapse-allCharterGroups-Mondseer_FormenVIII" class="collapse" aria-labelledby="allCharterGroupTableMondseer_FormenVIII" data-parent="#Mondseer_FormenCharterGroupAccordion">
                                     <div class="card-body">
-                                        <table id="allCharterGroupTableVIII" class="table table-sm table-hover table-bordered" aria-label="{{ _('Gesamte Urkundengruppe') }} {{ _("Gruppe") }} VIII">
+                                        <table id="allCharterGroupTableMondseer_FormenVIII" class="table table-sm table-hover table-bordered" aria-label="{{ _("Tabelle") }}: Mondseer Formen  {{ _("Gruppe") }} VIII">
                                             <thead>
                                                 <tr>
                                                     <th id="all-charter-checkbox-column" scope="col"></th>
@@ -596,7 +596,7 @@
                                         </tr>
                                             </tbody>
                                         </table>
-                                        <button data-target="allCharterGroupTableVIII" class="btn btn-primary charter-select-button" type="button" aria-expanded="true">{{ _('Gewählte Urkunken lesen') }}</button>
+                                        <button data-target="allCharterGroupTableMondseer_FormenVIII" class="btn btn-primary charter-select-button" type="button" aria-expanded="true" disabled>{{ _('Gewählte Urkunken lesen') }}</button>
                                     </div>
                                 </div>
                         </div>
@@ -609,14 +609,14 @@
                         </h3>
                         <div class="accordion collapse" id="Passauer_FormenCharterGroupAccordion">
                         
-                                <h3 class="card-header" id="part-allCharterGroups-I">
-                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-I" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-I">
+                                <h3 class="card-header" id="part-allCharterGroups-Passauer_FormenI">
+                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-Passauer_FormenI" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-Passauer_FormenI">
                                     <h5>{{ _("Gruppe") }} I</h5>
                                     </button>
                                 </h3>
-                                <div id="part-collapse-allCharterGroups-I" class="collapse" aria-labelledby="allCharterGroupTableI" data-parent="#Passauer_FormenCharterGroupAccordion">
+                                <div id="part-collapse-allCharterGroups-Passauer_FormenI" class="collapse" aria-labelledby="allCharterGroupTablePassauer_FormenI" data-parent="#Passauer_FormenCharterGroupAccordion">
                                     <div class="card-body">
-                                        <table id="allCharterGroupTableI" class="table table-sm table-hover table-bordered" aria-label="{{ _('Gesamte Urkundengruppe') }} {{ _("Gruppe") }} I">
+                                        <table id="allCharterGroupTablePassauer_FormenI" class="table table-sm table-hover table-bordered" aria-label="{{ _("Tabelle") }}: Passauer Formen  {{ _("Gruppe") }} I">
                                             <thead>
                                                 <tr>
                                                     <th id="all-charter-checkbox-column" scope="col"></th>
@@ -668,17 +668,17 @@
                                         </tr>
                                             </tbody>
                                         </table>
-                                        <button data-target="allCharterGroupTableI" class="btn btn-primary charter-select-button" type="button" aria-expanded="true">{{ _('Gewählte Urkunken lesen') }}</button>
+                                        <button data-target="allCharterGroupTablePassauer_FormenI" class="btn btn-primary charter-select-button" type="button" aria-expanded="true" disabled>{{ _('Gewählte Urkunken lesen') }}</button>
                                     </div>
                                 </div>
-                                <h3 class="card-header" id="part-allCharterGroups-II">
-                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-II" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-II">
+                                <h3 class="card-header" id="part-allCharterGroups-Passauer_FormenII">
+                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-Passauer_FormenII" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-Passauer_FormenII">
                                     <h5>{{ _("Gruppe") }} II</h5>
                                     </button>
                                 </h3>
-                                <div id="part-collapse-allCharterGroups-II" class="collapse" aria-labelledby="allCharterGroupTableII" data-parent="#Passauer_FormenCharterGroupAccordion">
+                                <div id="part-collapse-allCharterGroups-Passauer_FormenII" class="collapse" aria-labelledby="allCharterGroupTablePassauer_FormenII" data-parent="#Passauer_FormenCharterGroupAccordion">
                                     <div class="card-body">
-                                        <table id="allCharterGroupTableII" class="table table-sm table-hover table-bordered" aria-label="{{ _('Gesamte Urkundengruppe') }} {{ _("Gruppe") }} II">
+                                        <table id="allCharterGroupTablePassauer_FormenII" class="table table-sm table-hover table-bordered" aria-label="{{ _("Tabelle") }}: Passauer Formen  {{ _("Gruppe") }} II">
                                             <thead>
                                                 <tr>
                                                     <th id="all-charter-checkbox-column" scope="col"></th>
@@ -710,17 +710,17 @@
                                         </tr>
                                             </tbody>
                                         </table>
-                                        <button data-target="allCharterGroupTableII" class="btn btn-primary charter-select-button" type="button" aria-expanded="true">{{ _('Gewählte Urkunken lesen') }}</button>
+                                        <button data-target="allCharterGroupTablePassauer_FormenII" class="btn btn-primary charter-select-button" type="button" aria-expanded="true" disabled>{{ _('Gewählte Urkunken lesen') }}</button>
                                     </div>
                                 </div>
-                                <h3 class="card-header" id="part-allCharterGroups-III">
-                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-III" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-III">
+                                <h3 class="card-header" id="part-allCharterGroups-Passauer_FormenIII">
+                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-Passauer_FormenIII" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-Passauer_FormenIII">
                                     <h5>{{ _("Gruppe") }} III</h5>
                                     </button>
                                 </h3>
-                                <div id="part-collapse-allCharterGroups-III" class="collapse" aria-labelledby="allCharterGroupTableIII" data-parent="#Passauer_FormenCharterGroupAccordion">
+                                <div id="part-collapse-allCharterGroups-Passauer_FormenIII" class="collapse" aria-labelledby="allCharterGroupTablePassauer_FormenIII" data-parent="#Passauer_FormenCharterGroupAccordion">
                                     <div class="card-body">
-                                        <table id="allCharterGroupTableIII" class="table table-sm table-hover table-bordered" aria-label="{{ _('Gesamte Urkundengruppe') }} {{ _("Gruppe") }} III">
+                                        <table id="allCharterGroupTablePassauer_FormenIII" class="table table-sm table-hover table-bordered" aria-label="{{ _("Tabelle") }}: Passauer Formen  {{ _("Gruppe") }} III">
                                             <thead>
                                                 <tr>
                                                     <th id="all-charter-checkbox-column" scope="col"></th>
@@ -757,17 +757,17 @@
                                         </tr>
                                             </tbody>
                                         </table>
-                                        <button data-target="allCharterGroupTableIII" class="btn btn-primary charter-select-button" type="button" aria-expanded="true">{{ _('Gewählte Urkunken lesen') }}</button>
+                                        <button data-target="allCharterGroupTablePassauer_FormenIII" class="btn btn-primary charter-select-button" type="button" aria-expanded="true" disabled>{{ _('Gewählte Urkunken lesen') }}</button>
                                     </div>
                                 </div>
-                                <h3 class="card-header" id="part-allCharterGroups-IV">
-                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-IV" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-IV">
+                                <h3 class="card-header" id="part-allCharterGroups-Passauer_FormenIV">
+                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-Passauer_FormenIV" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-Passauer_FormenIV">
                                     <h5>{{ _("Gruppe") }} IV</h5>
                                     </button>
                                 </h3>
-                                <div id="part-collapse-allCharterGroups-IV" class="collapse" aria-labelledby="allCharterGroupTableIV" data-parent="#Passauer_FormenCharterGroupAccordion">
+                                <div id="part-collapse-allCharterGroups-Passauer_FormenIV" class="collapse" aria-labelledby="allCharterGroupTablePassauer_FormenIV" data-parent="#Passauer_FormenCharterGroupAccordion">
                                     <div class="card-body">
-                                        <table id="allCharterGroupTableIV" class="table table-sm table-hover table-bordered" aria-label="{{ _('Gesamte Urkundengruppe') }} {{ _("Gruppe") }} IV">
+                                        <table id="allCharterGroupTablePassauer_FormenIV" class="table table-sm table-hover table-bordered" aria-label="{{ _("Tabelle") }}: Passauer Formen  {{ _("Gruppe") }} IV">
                                             <thead>
                                                 <tr>
                                                     <th id="all-charter-checkbox-column" scope="col"></th>
@@ -799,17 +799,17 @@
                                         </tr>
                                             </tbody>
                                         </table>
-                                        <button data-target="allCharterGroupTableIV" class="btn btn-primary charter-select-button" type="button" aria-expanded="true">{{ _('Gewählte Urkunken lesen') }}</button>
+                                        <button data-target="allCharterGroupTablePassauer_FormenIV" class="btn btn-primary charter-select-button" type="button" aria-expanded="true" disabled>{{ _('Gewählte Urkunken lesen') }}</button>
                                     </div>
                                 </div>
-                                <h3 class="card-header" id="part-allCharterGroups-Va">
-                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-Va" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-Va">
+                                <h3 class="card-header" id="part-allCharterGroups-Passauer_FormenVa">
+                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-Passauer_FormenVa" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-Passauer_FormenVa">
                                     <h5>{{ _("Gruppe") }} Va</h5>
                                     </button>
                                 </h3>
-                                <div id="part-collapse-allCharterGroups-Va" class="collapse" aria-labelledby="allCharterGroupTableVa" data-parent="#Passauer_FormenCharterGroupAccordion">
+                                <div id="part-collapse-allCharterGroups-Passauer_FormenVa" class="collapse" aria-labelledby="allCharterGroupTablePassauer_FormenVa" data-parent="#Passauer_FormenCharterGroupAccordion">
                                     <div class="card-body">
-                                        <table id="allCharterGroupTableVa" class="table table-sm table-hover table-bordered" aria-label="{{ _('Gesamte Urkundengruppe') }} {{ _("Gruppe") }} Va">
+                                        <table id="allCharterGroupTablePassauer_FormenVa" class="table table-sm table-hover table-bordered" aria-label="{{ _("Tabelle") }}: Passauer Formen  {{ _("Gruppe") }} Va">
                                             <thead>
                                                 <tr>
                                                     <th id="all-charter-checkbox-column" scope="col"></th>
@@ -851,17 +851,17 @@
                                         </tr>
                                             </tbody>
                                         </table>
-                                        <button data-target="allCharterGroupTableVa" class="btn btn-primary charter-select-button" type="button" aria-expanded="true">{{ _('Gewählte Urkunken lesen') }}</button>
+                                        <button data-target="allCharterGroupTablePassauer_FormenVa" class="btn btn-primary charter-select-button" type="button" aria-expanded="true" disabled>{{ _('Gewählte Urkunken lesen') }}</button>
                                     </div>
                                 </div>
-                                <h3 class="card-header" id="part-allCharterGroups-Vb">
-                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-Vb" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-Vb">
+                                <h3 class="card-header" id="part-allCharterGroups-Passauer_FormenVb">
+                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-Passauer_FormenVb" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-Passauer_FormenVb">
                                     <h5>{{ _("Gruppe") }} Vb</h5>
                                     </button>
                                 </h3>
-                                <div id="part-collapse-allCharterGroups-Vb" class="collapse" aria-labelledby="allCharterGroupTableVb" data-parent="#Passauer_FormenCharterGroupAccordion">
+                                <div id="part-collapse-allCharterGroups-Passauer_FormenVb" class="collapse" aria-labelledby="allCharterGroupTablePassauer_FormenVb" data-parent="#Passauer_FormenCharterGroupAccordion">
                                     <div class="card-body">
-                                        <table id="allCharterGroupTableVb" class="table table-sm table-hover table-bordered" aria-label="{{ _('Gesamte Urkundengruppe') }} {{ _("Gruppe") }} Vb">
+                                        <table id="allCharterGroupTablePassauer_FormenVb" class="table table-sm table-hover table-bordered" aria-label="{{ _("Tabelle") }}: Passauer Formen  {{ _("Gruppe") }} Vb">
                                             <thead>
                                                 <tr>
                                                     <th id="all-charter-checkbox-column" scope="col"></th>
@@ -893,17 +893,17 @@
                                         </tr>
                                             </tbody>
                                         </table>
-                                        <button data-target="allCharterGroupTableVb" class="btn btn-primary charter-select-button" type="button" aria-expanded="true">{{ _('Gewählte Urkunken lesen') }}</button>
+                                        <button data-target="allCharterGroupTablePassauer_FormenVb" class="btn btn-primary charter-select-button" type="button" aria-expanded="true" disabled>{{ _('Gewählte Urkunken lesen') }}</button>
                                     </div>
                                 </div>
-                                <h3 class="card-header" id="part-allCharterGroups-VI">
-                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-VI" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-VI">
+                                <h3 class="card-header" id="part-allCharterGroups-Passauer_FormenVI">
+                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-Passauer_FormenVI" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-Passauer_FormenVI">
                                     <h5>{{ _("Gruppe") }} VI</h5>
                                     </button>
                                 </h3>
-                                <div id="part-collapse-allCharterGroups-VI" class="collapse" aria-labelledby="allCharterGroupTableVI" data-parent="#Passauer_FormenCharterGroupAccordion">
+                                <div id="part-collapse-allCharterGroups-Passauer_FormenVI" class="collapse" aria-labelledby="allCharterGroupTablePassauer_FormenVI" data-parent="#Passauer_FormenCharterGroupAccordion">
                                     <div class="card-body">
-                                        <table id="allCharterGroupTableVI" class="table table-sm table-hover table-bordered" aria-label="{{ _('Gesamte Urkundengruppe') }} {{ _("Gruppe") }} VI">
+                                        <table id="allCharterGroupTablePassauer_FormenVI" class="table table-sm table-hover table-bordered" aria-label="{{ _("Tabelle") }}: Passauer Formen  {{ _("Gruppe") }} VI">
                                             <thead>
                                                 <tr>
                                                     <th id="all-charter-checkbox-column" scope="col"></th>
@@ -925,17 +925,17 @@
                                         </tr>
                                             </tbody>
                                         </table>
-                                        <button data-target="allCharterGroupTableVI" class="btn btn-primary charter-select-button" type="button" aria-expanded="true">{{ _('Gewählte Urkunken lesen') }}</button>
+                                        <button data-target="allCharterGroupTablePassauer_FormenVI" class="btn btn-primary charter-select-button" type="button" aria-expanded="true" disabled>{{ _('Gewählte Urkunken lesen') }}</button>
                                     </div>
                                 </div>
-                                <h3 class="card-header" id="part-allCharterGroups-VII">
-                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-VII" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-VII">
+                                <h3 class="card-header" id="part-allCharterGroups-Passauer_FormenVII">
+                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-Passauer_FormenVII" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-Passauer_FormenVII">
                                     <h5>{{ _("Gruppe") }} VII</h5>
                                     </button>
                                 </h3>
-                                <div id="part-collapse-allCharterGroups-VII" class="collapse" aria-labelledby="allCharterGroupTableVII" data-parent="#Passauer_FormenCharterGroupAccordion">
+                                <div id="part-collapse-allCharterGroups-Passauer_FormenVII" class="collapse" aria-labelledby="allCharterGroupTablePassauer_FormenVII" data-parent="#Passauer_FormenCharterGroupAccordion">
                                     <div class="card-body">
-                                        <table id="allCharterGroupTableVII" class="table table-sm table-hover table-bordered" aria-label="{{ _('Gesamte Urkundengruppe') }} {{ _("Gruppe") }} VII">
+                                        <table id="allCharterGroupTablePassauer_FormenVII" class="table table-sm table-hover table-bordered" aria-label="{{ _("Tabelle") }}: Passauer Formen  {{ _("Gruppe") }} VII">
                                             <thead>
                                                 <tr>
                                                     <th id="all-charter-checkbox-column" scope="col"></th>
@@ -957,17 +957,17 @@
                                         </tr>
                                             </tbody>
                                         </table>
-                                        <button data-target="allCharterGroupTableVII" class="btn btn-primary charter-select-button" type="button" aria-expanded="true">{{ _('Gewählte Urkunken lesen') }}</button>
+                                        <button data-target="allCharterGroupTablePassauer_FormenVII" class="btn btn-primary charter-select-button" type="button" aria-expanded="true" disabled>{{ _('Gewählte Urkunken lesen') }}</button>
                                     </div>
                                 </div>
-                                <h3 class="card-header" id="part-allCharterGroups-VIII">
-                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-VIII" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-VIII">
+                                <h3 class="card-header" id="part-allCharterGroups-Passauer_FormenVIII">
+                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-Passauer_FormenVIII" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-Passauer_FormenVIII">
                                     <h5>{{ _("Gruppe") }} VIII</h5>
                                     </button>
                                 </h3>
-                                <div id="part-collapse-allCharterGroups-VIII" class="collapse" aria-labelledby="allCharterGroupTableVIII" data-parent="#Passauer_FormenCharterGroupAccordion">
+                                <div id="part-collapse-allCharterGroups-Passauer_FormenVIII" class="collapse" aria-labelledby="allCharterGroupTablePassauer_FormenVIII" data-parent="#Passauer_FormenCharterGroupAccordion">
                                     <div class="card-body">
-                                        <table id="allCharterGroupTableVIII" class="table table-sm table-hover table-bordered" aria-label="{{ _('Gesamte Urkundengruppe') }} {{ _("Gruppe") }} VIII">
+                                        <table id="allCharterGroupTablePassauer_FormenVIII" class="table table-sm table-hover table-bordered" aria-label="{{ _("Tabelle") }}: Passauer Formen  {{ _("Gruppe") }} VIII">
                                             <thead>
                                                 <tr>
                                                     <th id="all-charter-checkbox-column" scope="col"></th>
@@ -989,7 +989,7 @@
                                         </tr>
                                             </tbody>
                                         </table>
-                                        <button data-target="allCharterGroupTableVIII" class="btn btn-primary charter-select-button" type="button" aria-expanded="true">{{ _('Gewählte Urkunken lesen') }}</button>
+                                        <button data-target="allCharterGroupTablePassauer_FormenVIII" class="btn btn-primary charter-select-button" type="button" aria-expanded="true" disabled>{{ _('Gewählte Urkunken lesen') }}</button>
                                     </div>
                                 </div>
                         </div>
@@ -1002,14 +1002,14 @@
                         </h3>
                         <div class="accordion collapse" id="Schäftlarner_FormenCharterGroupAccordion">
                         
-                                <h3 class="card-header" id="part-allCharterGroups-I">
-                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-I" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-I">
+                                <h3 class="card-header" id="part-allCharterGroups-Schäftlarner_FormenI">
+                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-Schäftlarner_FormenI" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-Schäftlarner_FormenI">
                                     <h5>{{ _("Gruppe") }} I</h5>
                                     </button>
                                 </h3>
-                                <div id="part-collapse-allCharterGroups-I" class="collapse" aria-labelledby="allCharterGroupTableI" data-parent="#Schäftlarner_FormenCharterGroupAccordion">
+                                <div id="part-collapse-allCharterGroups-Schäftlarner_FormenI" class="collapse" aria-labelledby="allCharterGroupTableSchäftlarner_FormenI" data-parent="#Schäftlarner_FormenCharterGroupAccordion">
                                     <div class="card-body">
-                                        <table id="allCharterGroupTableI" class="table table-sm table-hover table-bordered" aria-label="{{ _('Gesamte Urkundengruppe') }} {{ _("Gruppe") }} I">
+                                        <table id="allCharterGroupTableSchäftlarner_FormenI" class="table table-sm table-hover table-bordered" aria-label="{{ _("Tabelle") }}: Schäftlarner Formen  {{ _("Gruppe") }} I">
                                             <thead>
                                                 <tr>
                                                     <th id="all-charter-checkbox-column" scope="col"></th>
@@ -1056,7 +1056,7 @@
                                         </tr>
                                             </tbody>
                                         </table>
-                                        <button data-target="allCharterGroupTableI" class="btn btn-primary charter-select-button" type="button" aria-expanded="true">{{ _('Gewählte Urkunken lesen') }}</button>
+                                        <button data-target="allCharterGroupTableSchäftlarner_FormenI" class="btn btn-primary charter-select-button" type="button" aria-expanded="true" disabled>{{ _('Gewählte Urkunken lesen') }}</button>
                                     </div>
                                 </div>
                         </div>
@@ -1069,14 +1069,14 @@
                         </h3>
                         <div class="accordion collapse" id="St_Galler_FormenCharterGroupAccordion">
                         
-                                <h3 class="card-header" id="part-allCharterGroups-I">
-                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-I" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-I">
+                                <h3 class="card-header" id="part-allCharterGroups-St_Galler_FormenI">
+                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-St_Galler_FormenI" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-St_Galler_FormenI">
                                     <h5>{{ _("Gruppe") }} I</h5>
                                     </button>
                                 </h3>
-                                <div id="part-collapse-allCharterGroups-I" class="collapse" aria-labelledby="allCharterGroupTableI" data-parent="#St_Galler_FormenCharterGroupAccordion">
+                                <div id="part-collapse-allCharterGroups-St_Galler_FormenI" class="collapse" aria-labelledby="allCharterGroupTableSt_Galler_FormenI" data-parent="#St_Galler_FormenCharterGroupAccordion">
                                     <div class="card-body">
-                                        <table id="allCharterGroupTableI" class="table table-sm table-hover table-bordered" aria-label="{{ _('Gesamte Urkundengruppe') }} {{ _("Gruppe") }} I">
+                                        <table id="allCharterGroupTableSt_Galler_FormenI" class="table table-sm table-hover table-bordered" aria-label="{{ _("Tabelle") }}: St. Galler Formen  {{ _("Gruppe") }} I">
                                             <thead>
                                                 <tr>
                                                     <th id="all-charter-checkbox-column" scope="col"></th>
@@ -1128,17 +1128,17 @@
                                         </tr>
                                             </tbody>
                                         </table>
-                                        <button data-target="allCharterGroupTableI" class="btn btn-primary charter-select-button" type="button" aria-expanded="true">{{ _('Gewählte Urkunken lesen') }}</button>
+                                        <button data-target="allCharterGroupTableSt_Galler_FormenI" class="btn btn-primary charter-select-button" type="button" aria-expanded="true" disabled>{{ _('Gewählte Urkunken lesen') }}</button>
                                     </div>
                                 </div>
-                                <h3 class="card-header" id="part-allCharterGroups-II">
-                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-II" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-II">
+                                <h3 class="card-header" id="part-allCharterGroups-St_Galler_FormenII">
+                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-St_Galler_FormenII" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-St_Galler_FormenII">
                                     <h5>{{ _("Gruppe") }} II</h5>
                                     </button>
                                 </h3>
-                                <div id="part-collapse-allCharterGroups-II" class="collapse" aria-labelledby="allCharterGroupTableII" data-parent="#St_Galler_FormenCharterGroupAccordion">
+                                <div id="part-collapse-allCharterGroups-St_Galler_FormenII" class="collapse" aria-labelledby="allCharterGroupTableSt_Galler_FormenII" data-parent="#St_Galler_FormenCharterGroupAccordion">
                                     <div class="card-body">
-                                        <table id="allCharterGroupTableII" class="table table-sm table-hover table-bordered" aria-label="{{ _('Gesamte Urkundengruppe') }} {{ _("Gruppe") }} II">
+                                        <table id="allCharterGroupTableSt_Galler_FormenII" class="table table-sm table-hover table-bordered" aria-label="{{ _("Tabelle") }}: St. Galler Formen  {{ _("Gruppe") }} II">
                                             <thead>
                                                 <tr>
                                                     <th id="all-charter-checkbox-column" scope="col"></th>
@@ -1170,17 +1170,17 @@
                                         </tr>
                                             </tbody>
                                         </table>
-                                        <button data-target="allCharterGroupTableII" class="btn btn-primary charter-select-button" type="button" aria-expanded="true">{{ _('Gewählte Urkunken lesen') }}</button>
+                                        <button data-target="allCharterGroupTableSt_Galler_FormenII" class="btn btn-primary charter-select-button" type="button" aria-expanded="true" disabled>{{ _('Gewählte Urkunken lesen') }}</button>
                                     </div>
                                 </div>
-                                <h3 class="card-header" id="part-allCharterGroups-III">
-                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-III" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-III">
+                                <h3 class="card-header" id="part-allCharterGroups-St_Galler_FormenIII">
+                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-St_Galler_FormenIII" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-St_Galler_FormenIII">
                                     <h5>{{ _("Gruppe") }} III</h5>
                                     </button>
                                 </h3>
-                                <div id="part-collapse-allCharterGroups-III" class="collapse" aria-labelledby="allCharterGroupTableIII" data-parent="#St_Galler_FormenCharterGroupAccordion">
+                                <div id="part-collapse-allCharterGroups-St_Galler_FormenIII" class="collapse" aria-labelledby="allCharterGroupTableSt_Galler_FormenIII" data-parent="#St_Galler_FormenCharterGroupAccordion">
                                     <div class="card-body">
-                                        <table id="allCharterGroupTableIII" class="table table-sm table-hover table-bordered" aria-label="{{ _('Gesamte Urkundengruppe') }} {{ _("Gruppe") }} III">
+                                        <table id="allCharterGroupTableSt_Galler_FormenIII" class="table table-sm table-hover table-bordered" aria-label="{{ _("Tabelle") }}: St. Galler Formen  {{ _("Gruppe") }} III">
                                             <thead>
                                                 <tr>
                                                     <th id="all-charter-checkbox-column" scope="col"></th>
@@ -1307,17 +1307,17 @@
                                         </tr>
                                             </tbody>
                                         </table>
-                                        <button data-target="allCharterGroupTableIII" class="btn btn-primary charter-select-button" type="button" aria-expanded="true">{{ _('Gewählte Urkunken lesen') }}</button>
+                                        <button data-target="allCharterGroupTableSt_Galler_FormenIII" class="btn btn-primary charter-select-button" type="button" aria-expanded="true" disabled>{{ _('Gewählte Urkunken lesen') }}</button>
                                     </div>
                                 </div>
-                                <h3 class="card-header" id="part-allCharterGroups-IV">
-                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-IV" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-IV">
+                                <h3 class="card-header" id="part-allCharterGroups-St_Galler_FormenIV">
+                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-St_Galler_FormenIV" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-St_Galler_FormenIV">
                                     <h5>{{ _("Gruppe") }} IV</h5>
                                     </button>
                                 </h3>
-                                <div id="part-collapse-allCharterGroups-IV" class="collapse" aria-labelledby="allCharterGroupTableIV" data-parent="#St_Galler_FormenCharterGroupAccordion">
+                                <div id="part-collapse-allCharterGroups-St_Galler_FormenIV" class="collapse" aria-labelledby="allCharterGroupTableSt_Galler_FormenIV" data-parent="#St_Galler_FormenCharterGroupAccordion">
                                     <div class="card-body">
-                                        <table id="allCharterGroupTableIV" class="table table-sm table-hover table-bordered" aria-label="{{ _('Gesamte Urkundengruppe') }} {{ _("Gruppe") }} IV">
+                                        <table id="allCharterGroupTableSt_Galler_FormenIV" class="table table-sm table-hover table-bordered" aria-label="{{ _("Tabelle") }}: St. Galler Formen  {{ _("Gruppe") }} IV">
                                             <thead>
                                                 <tr>
                                                     <th id="all-charter-checkbox-column" scope="col"></th>
@@ -1344,17 +1344,17 @@
                                         </tr>
                                             </tbody>
                                         </table>
-                                        <button data-target="allCharterGroupTableIV" class="btn btn-primary charter-select-button" type="button" aria-expanded="true">{{ _('Gewählte Urkunken lesen') }}</button>
+                                        <button data-target="allCharterGroupTableSt_Galler_FormenIV" class="btn btn-primary charter-select-button" type="button" aria-expanded="true" disabled>{{ _('Gewählte Urkunken lesen') }}</button>
                                     </div>
                                 </div>
-                                <h3 class="card-header" id="part-allCharterGroups-V">
-                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-V" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-V">
+                                <h3 class="card-header" id="part-allCharterGroups-St_Galler_FormenV">
+                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-St_Galler_FormenV" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-St_Galler_FormenV">
                                     <h5>{{ _("Gruppe") }} V</h5>
                                     </button>
                                 </h3>
-                                <div id="part-collapse-allCharterGroups-V" class="collapse" aria-labelledby="allCharterGroupTableV" data-parent="#St_Galler_FormenCharterGroupAccordion">
+                                <div id="part-collapse-allCharterGroups-St_Galler_FormenV" class="collapse" aria-labelledby="allCharterGroupTableSt_Galler_FormenV" data-parent="#St_Galler_FormenCharterGroupAccordion">
                                     <div class="card-body">
-                                        <table id="allCharterGroupTableV" class="table table-sm table-hover table-bordered" aria-label="{{ _('Gesamte Urkundengruppe') }} {{ _("Gruppe") }} V">
+                                        <table id="allCharterGroupTableSt_Galler_FormenV" class="table table-sm table-hover table-bordered" aria-label="{{ _("Tabelle") }}: St. Galler Formen  {{ _("Gruppe") }} V">
                                             <thead>
                                                 <tr>
                                                     <th id="all-charter-checkbox-column" scope="col"></th>
@@ -1446,17 +1446,17 @@
                                         </tr>
                                             </tbody>
                                         </table>
-                                        <button data-target="allCharterGroupTableV" class="btn btn-primary charter-select-button" type="button" aria-expanded="true">{{ _('Gewählte Urkunken lesen') }}</button>
+                                        <button data-target="allCharterGroupTableSt_Galler_FormenV" class="btn btn-primary charter-select-button" type="button" aria-expanded="true" disabled>{{ _('Gewählte Urkunken lesen') }}</button>
                                     </div>
                                 </div>
-                                <h3 class="card-header" id="part-allCharterGroups-VI">
-                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-VI" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-VI">
+                                <h3 class="card-header" id="part-allCharterGroups-St_Galler_FormenVI">
+                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-St_Galler_FormenVI" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-St_Galler_FormenVI">
                                     <h5>{{ _("Gruppe") }} VI</h5>
                                     </button>
                                 </h3>
-                                <div id="part-collapse-allCharterGroups-VI" class="collapse" aria-labelledby="allCharterGroupTableVI" data-parent="#St_Galler_FormenCharterGroupAccordion">
+                                <div id="part-collapse-allCharterGroups-St_Galler_FormenVI" class="collapse" aria-labelledby="allCharterGroupTableSt_Galler_FormenVI" data-parent="#St_Galler_FormenCharterGroupAccordion">
                                     <div class="card-body">
-                                        <table id="allCharterGroupTableVI" class="table table-sm table-hover table-bordered" aria-label="{{ _('Gesamte Urkundengruppe') }} {{ _("Gruppe") }} VI">
+                                        <table id="allCharterGroupTableSt_Galler_FormenVI" class="table table-sm table-hover table-bordered" aria-label="{{ _("Tabelle") }}: St. Galler Formen  {{ _("Gruppe") }} VI">
                                             <thead>
                                                 <tr>
                                                     <th id="all-charter-checkbox-column" scope="col"></th>
@@ -1493,17 +1493,17 @@
                                         </tr>
                                             </tbody>
                                         </table>
-                                        <button data-target="allCharterGroupTableVI" class="btn btn-primary charter-select-button" type="button" aria-expanded="true">{{ _('Gewählte Urkunken lesen') }}</button>
+                                        <button data-target="allCharterGroupTableSt_Galler_FormenVI" class="btn btn-primary charter-select-button" type="button" aria-expanded="true" disabled>{{ _('Gewählte Urkunken lesen') }}</button>
                                     </div>
                                 </div>
-                                <h3 class="card-header" id="part-allCharterGroups-VII">
-                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-VII" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-VII">
+                                <h3 class="card-header" id="part-allCharterGroups-St_Galler_FormenVII">
+                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-St_Galler_FormenVII" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-St_Galler_FormenVII">
                                     <h5>{{ _("Gruppe") }} VII</h5>
                                     </button>
                                 </h3>
-                                <div id="part-collapse-allCharterGroups-VII" class="collapse" aria-labelledby="allCharterGroupTableVII" data-parent="#St_Galler_FormenCharterGroupAccordion">
+                                <div id="part-collapse-allCharterGroups-St_Galler_FormenVII" class="collapse" aria-labelledby="allCharterGroupTableSt_Galler_FormenVII" data-parent="#St_Galler_FormenCharterGroupAccordion">
                                     <div class="card-body">
-                                        <table id="allCharterGroupTableVII" class="table table-sm table-hover table-bordered" aria-label="{{ _('Gesamte Urkundengruppe') }} {{ _("Gruppe") }} VII">
+                                        <table id="allCharterGroupTableSt_Galler_FormenVII" class="table table-sm table-hover table-bordered" aria-label="{{ _("Tabelle") }}: St. Galler Formen  {{ _("Gruppe") }} VII">
                                             <thead>
                                                 <tr>
                                                     <th id="all-charter-checkbox-column" scope="col"></th>
@@ -1530,17 +1530,17 @@
                                         </tr>
                                             </tbody>
                                         </table>
-                                        <button data-target="allCharterGroupTableVII" class="btn btn-primary charter-select-button" type="button" aria-expanded="true">{{ _('Gewählte Urkunken lesen') }}</button>
+                                        <button data-target="allCharterGroupTableSt_Galler_FormenVII" class="btn btn-primary charter-select-button" type="button" aria-expanded="true" disabled>{{ _('Gewählte Urkunken lesen') }}</button>
                                     </div>
                                 </div>
-                                <h3 class="card-header" id="part-allCharterGroups-VIII">
-                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-VIII" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-VIII">
+                                <h3 class="card-header" id="part-allCharterGroups-St_Galler_FormenVIII">
+                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-St_Galler_FormenVIII" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-St_Galler_FormenVIII">
                                     <h5>{{ _("Gruppe") }} VIII</h5>
                                     </button>
                                 </h3>
-                                <div id="part-collapse-allCharterGroups-VIII" class="collapse" aria-labelledby="allCharterGroupTableVIII" data-parent="#St_Galler_FormenCharterGroupAccordion">
+                                <div id="part-collapse-allCharterGroups-St_Galler_FormenVIII" class="collapse" aria-labelledby="allCharterGroupTableSt_Galler_FormenVIII" data-parent="#St_Galler_FormenCharterGroupAccordion">
                                     <div class="card-body">
-                                        <table id="allCharterGroupTableVIII" class="table table-sm table-hover table-bordered" aria-label="{{ _('Gesamte Urkundengruppe') }} {{ _("Gruppe") }} VIII">
+                                        <table id="allCharterGroupTableSt_Galler_FormenVIII" class="table table-sm table-hover table-bordered" aria-label="{{ _("Tabelle") }}: St. Galler Formen  {{ _("Gruppe") }} VIII">
                                             <thead>
                                                 <tr>
                                                     <th id="all-charter-checkbox-column" scope="col"></th>
@@ -1587,17 +1587,17 @@
                                         </tr>
                                             </tbody>
                                         </table>
-                                        <button data-target="allCharterGroupTableVIII" class="btn btn-primary charter-select-button" type="button" aria-expanded="true">{{ _('Gewählte Urkunken lesen') }}</button>
+                                        <button data-target="allCharterGroupTableSt_Galler_FormenVIII" class="btn btn-primary charter-select-button" type="button" aria-expanded="true" disabled>{{ _('Gewählte Urkunken lesen') }}</button>
                                     </div>
                                 </div>
-                                <h3 class="card-header" id="part-allCharterGroups-IX">
-                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-IX" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-IX">
+                                <h3 class="card-header" id="part-allCharterGroups-St_Galler_FormenIX">
+                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-St_Galler_FormenIX" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-St_Galler_FormenIX">
                                     <h5>{{ _("Gruppe") }} IX</h5>
                                     </button>
                                 </h3>
-                                <div id="part-collapse-allCharterGroups-IX" class="collapse" aria-labelledby="allCharterGroupTableIX" data-parent="#St_Galler_FormenCharterGroupAccordion">
+                                <div id="part-collapse-allCharterGroups-St_Galler_FormenIX" class="collapse" aria-labelledby="allCharterGroupTableSt_Galler_FormenIX" data-parent="#St_Galler_FormenCharterGroupAccordion">
                                     <div class="card-body">
-                                        <table id="allCharterGroupTableIX" class="table table-sm table-hover table-bordered" aria-label="{{ _('Gesamte Urkundengruppe') }} {{ _("Gruppe") }} IX">
+                                        <table id="allCharterGroupTableSt_Galler_FormenIX" class="table table-sm table-hover table-bordered" aria-label="{{ _("Tabelle") }}: St. Galler Formen  {{ _("Gruppe") }} IX">
                                             <thead>
                                                 <tr>
                                                     <th id="all-charter-checkbox-column" scope="col"></th>
@@ -1644,17 +1644,17 @@
                                         </tr>
                                             </tbody>
                                         </table>
-                                        <button data-target="allCharterGroupTableIX" class="btn btn-primary charter-select-button" type="button" aria-expanded="true">{{ _('Gewählte Urkunken lesen') }}</button>
+                                        <button data-target="allCharterGroupTableSt_Galler_FormenIX" class="btn btn-primary charter-select-button" type="button" aria-expanded="true" disabled>{{ _('Gewählte Urkunken lesen') }}</button>
                                     </div>
                                 </div>
-                                <h3 class="card-header" id="part-allCharterGroups-X">
-                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-X" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-X">
+                                <h3 class="card-header" id="part-allCharterGroups-St_Galler_FormenX">
+                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-St_Galler_FormenX" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-St_Galler_FormenX">
                                     <h5>{{ _("Gruppe") }} X</h5>
                                     </button>
                                 </h3>
-                                <div id="part-collapse-allCharterGroups-X" class="collapse" aria-labelledby="allCharterGroupTableX" data-parent="#St_Galler_FormenCharterGroupAccordion">
+                                <div id="part-collapse-allCharterGroups-St_Galler_FormenX" class="collapse" aria-labelledby="allCharterGroupTableSt_Galler_FormenX" data-parent="#St_Galler_FormenCharterGroupAccordion">
                                     <div class="card-body">
-                                        <table id="allCharterGroupTableX" class="table table-sm table-hover table-bordered" aria-label="{{ _('Gesamte Urkundengruppe') }} {{ _("Gruppe") }} X">
+                                        <table id="allCharterGroupTableSt_Galler_FormenX" class="table table-sm table-hover table-bordered" aria-label="{{ _("Tabelle") }}: St. Galler Formen  {{ _("Gruppe") }} X">
                                             <thead>
                                                 <tr>
                                                     <th id="all-charter-checkbox-column" scope="col"></th>
@@ -1676,17 +1676,17 @@
                                         </tr>
                                             </tbody>
                                         </table>
-                                        <button data-target="allCharterGroupTableX" class="btn btn-primary charter-select-button" type="button" aria-expanded="true">{{ _('Gewählte Urkunken lesen') }}</button>
+                                        <button data-target="allCharterGroupTableSt_Galler_FormenX" class="btn btn-primary charter-select-button" type="button" aria-expanded="true" disabled>{{ _('Gewählte Urkunken lesen') }}</button>
                                     </div>
                                 </div>
-                                <h3 class="card-header" id="part-allCharterGroups-XI">
-                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-XI" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-XI">
+                                <h3 class="card-header" id="part-allCharterGroups-St_Galler_FormenXI">
+                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-St_Galler_FormenXI" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-St_Galler_FormenXI">
                                     <h5>{{ _("Gruppe") }} XI</h5>
                                     </button>
                                 </h3>
-                                <div id="part-collapse-allCharterGroups-XI" class="collapse" aria-labelledby="allCharterGroupTableXI" data-parent="#St_Galler_FormenCharterGroupAccordion">
+                                <div id="part-collapse-allCharterGroups-St_Galler_FormenXI" class="collapse" aria-labelledby="allCharterGroupTableSt_Galler_FormenXI" data-parent="#St_Galler_FormenCharterGroupAccordion">
                                     <div class="card-body">
-                                        <table id="allCharterGroupTableXI" class="table table-sm table-hover table-bordered" aria-label="{{ _('Gesamte Urkundengruppe') }} {{ _("Gruppe") }} XI">
+                                        <table id="allCharterGroupTableSt_Galler_FormenXI" class="table table-sm table-hover table-bordered" aria-label="{{ _("Tabelle") }}: St. Galler Formen  {{ _("Gruppe") }} XI">
                                             <thead>
                                                 <tr>
                                                     <th id="all-charter-checkbox-column" scope="col"></th>
@@ -1768,17 +1768,17 @@
                                         </tr>
                                             </tbody>
                                         </table>
-                                        <button data-target="allCharterGroupTableXI" class="btn btn-primary charter-select-button" type="button" aria-expanded="true">{{ _('Gewählte Urkunken lesen') }}</button>
+                                        <button data-target="allCharterGroupTableSt_Galler_FormenXI" class="btn btn-primary charter-select-button" type="button" aria-expanded="true" disabled>{{ _('Gewählte Urkunken lesen') }}</button>
                                     </div>
                                 </div>
-                                <h3 class="card-header" id="part-allCharterGroups-XIb">
-                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-XIb" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-XIb">
+                                <h3 class="card-header" id="part-allCharterGroups-St_Galler_FormenXIb">
+                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-St_Galler_FormenXIb" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-St_Galler_FormenXIb">
                                     <h5>{{ _("Gruppe") }} XIb</h5>
                                     </button>
                                 </h3>
-                                <div id="part-collapse-allCharterGroups-XIb" class="collapse" aria-labelledby="allCharterGroupTableXIb" data-parent="#St_Galler_FormenCharterGroupAccordion">
+                                <div id="part-collapse-allCharterGroups-St_Galler_FormenXIb" class="collapse" aria-labelledby="allCharterGroupTableSt_Galler_FormenXIb" data-parent="#St_Galler_FormenCharterGroupAccordion">
                                     <div class="card-body">
-                                        <table id="allCharterGroupTableXIb" class="table table-sm table-hover table-bordered" aria-label="{{ _('Gesamte Urkundengruppe') }} {{ _("Gruppe") }} XIb">
+                                        <table id="allCharterGroupTableSt_Galler_FormenXIb" class="table table-sm table-hover table-bordered" aria-label="{{ _("Tabelle") }}: St. Galler Formen  {{ _("Gruppe") }} XIb">
                                             <thead>
                                                 <tr>
                                                     <th id="all-charter-checkbox-column" scope="col"></th>
@@ -1860,17 +1860,17 @@
                                         </tr>
                                             </tbody>
                                         </table>
-                                        <button data-target="allCharterGroupTableXIb" class="btn btn-primary charter-select-button" type="button" aria-expanded="true">{{ _('Gewählte Urkunken lesen') }}</button>
+                                        <button data-target="allCharterGroupTableSt_Galler_FormenXIb" class="btn btn-primary charter-select-button" type="button" aria-expanded="true" disabled>{{ _('Gewählte Urkunken lesen') }}</button>
                                     </div>
                                 </div>
-                                <h3 class="card-header" id="part-allCharterGroups-XII">
-                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-XII" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-XII">
+                                <h3 class="card-header" id="part-allCharterGroups-St_Galler_FormenXII">
+                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-St_Galler_FormenXII" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-St_Galler_FormenXII">
                                     <h5>{{ _("Gruppe") }} XII</h5>
                                     </button>
                                 </h3>
-                                <div id="part-collapse-allCharterGroups-XII" class="collapse" aria-labelledby="allCharterGroupTableXII" data-parent="#St_Galler_FormenCharterGroupAccordion">
+                                <div id="part-collapse-allCharterGroups-St_Galler_FormenXII" class="collapse" aria-labelledby="allCharterGroupTableSt_Galler_FormenXII" data-parent="#St_Galler_FormenCharterGroupAccordion">
                                     <div class="card-body">
-                                        <table id="allCharterGroupTableXII" class="table table-sm table-hover table-bordered" aria-label="{{ _('Gesamte Urkundengruppe') }} {{ _("Gruppe") }} XII">
+                                        <table id="allCharterGroupTableSt_Galler_FormenXII" class="table table-sm table-hover table-bordered" aria-label="{{ _("Tabelle") }}: St. Galler Formen  {{ _("Gruppe") }} XII">
                                             <thead>
                                                 <tr>
                                                     <th id="all-charter-checkbox-column" scope="col"></th>
@@ -1927,17 +1927,17 @@
                                         </tr>
                                             </tbody>
                                         </table>
-                                        <button data-target="allCharterGroupTableXII" class="btn btn-primary charter-select-button" type="button" aria-expanded="true">{{ _('Gewählte Urkunken lesen') }}</button>
+                                        <button data-target="allCharterGroupTableSt_Galler_FormenXII" class="btn btn-primary charter-select-button" type="button" aria-expanded="true" disabled>{{ _('Gewählte Urkunken lesen') }}</button>
                                     </div>
                                 </div>
-                                <h3 class="card-header" id="part-allCharterGroups-XIII">
-                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-XIII" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-XIII">
+                                <h3 class="card-header" id="part-allCharterGroups-St_Galler_FormenXIII">
+                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-St_Galler_FormenXIII" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-St_Galler_FormenXIII">
                                     <h5>{{ _("Gruppe") }} XIII</h5>
                                     </button>
                                 </h3>
-                                <div id="part-collapse-allCharterGroups-XIII" class="collapse" aria-labelledby="allCharterGroupTableXIII" data-parent="#St_Galler_FormenCharterGroupAccordion">
+                                <div id="part-collapse-allCharterGroups-St_Galler_FormenXIII" class="collapse" aria-labelledby="allCharterGroupTableSt_Galler_FormenXIII" data-parent="#St_Galler_FormenCharterGroupAccordion">
                                     <div class="card-body">
-                                        <table id="allCharterGroupTableXIII" class="table table-sm table-hover table-bordered" aria-label="{{ _('Gesamte Urkundengruppe') }} {{ _("Gruppe") }} XIII">
+                                        <table id="allCharterGroupTableSt_Galler_FormenXIII" class="table table-sm table-hover table-bordered" aria-label="{{ _("Tabelle") }}: St. Galler Formen  {{ _("Gruppe") }} XIII">
                                             <thead>
                                                 <tr>
                                                     <th id="all-charter-checkbox-column" scope="col"></th>
@@ -2024,17 +2024,17 @@
                                         </tr>
                                             </tbody>
                                         </table>
-                                        <button data-target="allCharterGroupTableXIII" class="btn btn-primary charter-select-button" type="button" aria-expanded="true">{{ _('Gewählte Urkunken lesen') }}</button>
+                                        <button data-target="allCharterGroupTableSt_Galler_FormenXIII" class="btn btn-primary charter-select-button" type="button" aria-expanded="true" disabled>{{ _('Gewählte Urkunken lesen') }}</button>
                                     </div>
                                 </div>
-                                <h3 class="card-header" id="part-allCharterGroups-XIV">
-                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-XIV" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-XIV">
+                                <h3 class="card-header" id="part-allCharterGroups-St_Galler_FormenXIV">
+                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-St_Galler_FormenXIV" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-St_Galler_FormenXIV">
                                     <h5>{{ _("Gruppe") }} XIV</h5>
                                     </button>
                                 </h3>
-                                <div id="part-collapse-allCharterGroups-XIV" class="collapse" aria-labelledby="allCharterGroupTableXIV" data-parent="#St_Galler_FormenCharterGroupAccordion">
+                                <div id="part-collapse-allCharterGroups-St_Galler_FormenXIV" class="collapse" aria-labelledby="allCharterGroupTableSt_Galler_FormenXIV" data-parent="#St_Galler_FormenCharterGroupAccordion">
                                     <div class="card-body">
-                                        <table id="allCharterGroupTableXIV" class="table table-sm table-hover table-bordered" aria-label="{{ _('Gesamte Urkundengruppe') }} {{ _("Gruppe") }} XIV">
+                                        <table id="allCharterGroupTableSt_Galler_FormenXIV" class="table table-sm table-hover table-bordered" aria-label="{{ _("Tabelle") }}: St. Galler Formen  {{ _("Gruppe") }} XIV">
                                             <thead>
                                                 <tr>
                                                     <th id="all-charter-checkbox-column" scope="col"></th>
@@ -2056,17 +2056,17 @@
                                         </tr>
                                             </tbody>
                                         </table>
-                                        <button data-target="allCharterGroupTableXIV" class="btn btn-primary charter-select-button" type="button" aria-expanded="true">{{ _('Gewählte Urkunken lesen') }}</button>
+                                        <button data-target="allCharterGroupTableSt_Galler_FormenXIV" class="btn btn-primary charter-select-button" type="button" aria-expanded="true" disabled>{{ _('Gewählte Urkunken lesen') }}</button>
                                     </div>
                                 </div>
-                                <h3 class="card-header" id="part-allCharterGroups-XV">
-                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-XV" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-XV">
+                                <h3 class="card-header" id="part-allCharterGroups-St_Galler_FormenXV">
+                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-St_Galler_FormenXV" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-St_Galler_FormenXV">
                                     <h5>{{ _("Gruppe") }} XV</h5>
                                     </button>
                                 </h3>
-                                <div id="part-collapse-allCharterGroups-XV" class="collapse" aria-labelledby="allCharterGroupTableXV" data-parent="#St_Galler_FormenCharterGroupAccordion">
+                                <div id="part-collapse-allCharterGroups-St_Galler_FormenXV" class="collapse" aria-labelledby="allCharterGroupTableSt_Galler_FormenXV" data-parent="#St_Galler_FormenCharterGroupAccordion">
                                     <div class="card-body">
-                                        <table id="allCharterGroupTableXV" class="table table-sm table-hover table-bordered" aria-label="{{ _('Gesamte Urkundengruppe') }} {{ _("Gruppe") }} XV">
+                                        <table id="allCharterGroupTableSt_Galler_FormenXV" class="table table-sm table-hover table-bordered" aria-label="{{ _("Tabelle") }}: St. Galler Formen  {{ _("Gruppe") }} XV">
                                             <thead>
                                                 <tr>
                                                     <th id="all-charter-checkbox-column" scope="col"></th>
@@ -2128,17 +2128,17 @@
                                         </tr>
                                             </tbody>
                                         </table>
-                                        <button data-target="allCharterGroupTableXV" class="btn btn-primary charter-select-button" type="button" aria-expanded="true">{{ _('Gewählte Urkunken lesen') }}</button>
+                                        <button data-target="allCharterGroupTableSt_Galler_FormenXV" class="btn btn-primary charter-select-button" type="button" aria-expanded="true" disabled>{{ _('Gewählte Urkunken lesen') }}</button>
                                     </div>
                                 </div>
-                                <h3 class="card-header" id="part-allCharterGroups-XVI">
-                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-XVI" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-XVI">
+                                <h3 class="card-header" id="part-allCharterGroups-St_Galler_FormenXVI">
+                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-St_Galler_FormenXVI" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-St_Galler_FormenXVI">
                                     <h5>{{ _("Gruppe") }} XVI</h5>
                                     </button>
                                 </h3>
-                                <div id="part-collapse-allCharterGroups-XVI" class="collapse" aria-labelledby="allCharterGroupTableXVI" data-parent="#St_Galler_FormenCharterGroupAccordion">
+                                <div id="part-collapse-allCharterGroups-St_Galler_FormenXVI" class="collapse" aria-labelledby="allCharterGroupTableSt_Galler_FormenXVI" data-parent="#St_Galler_FormenCharterGroupAccordion">
                                     <div class="card-body">
-                                        <table id="allCharterGroupTableXVI" class="table table-sm table-hover table-bordered" aria-label="{{ _('Gesamte Urkundengruppe') }} {{ _("Gruppe") }} XVI">
+                                        <table id="allCharterGroupTableSt_Galler_FormenXVI" class="table table-sm table-hover table-bordered" aria-label="{{ _("Tabelle") }}: St. Galler Formen  {{ _("Gruppe") }} XVI">
                                             <thead>
                                                 <tr>
                                                     <th id="all-charter-checkbox-column" scope="col"></th>
@@ -2165,17 +2165,17 @@
                                         </tr>
                                             </tbody>
                                         </table>
-                                        <button data-target="allCharterGroupTableXVI" class="btn btn-primary charter-select-button" type="button" aria-expanded="true">{{ _('Gewählte Urkunken lesen') }}</button>
+                                        <button data-target="allCharterGroupTableSt_Galler_FormenXVI" class="btn btn-primary charter-select-button" type="button" aria-expanded="true" disabled>{{ _('Gewählte Urkunken lesen') }}</button>
                                     </div>
                                 </div>
-                                <h3 class="card-header" id="part-allCharterGroups-XVII">
-                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-XVII" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-XVII">
+                                <h3 class="card-header" id="part-allCharterGroups-St_Galler_FormenXVII">
+                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-St_Galler_FormenXVII" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-St_Galler_FormenXVII">
                                     <h5>{{ _("Gruppe") }} XVII</h5>
                                     </button>
                                 </h3>
-                                <div id="part-collapse-allCharterGroups-XVII" class="collapse" aria-labelledby="allCharterGroupTableXVII" data-parent="#St_Galler_FormenCharterGroupAccordion">
+                                <div id="part-collapse-allCharterGroups-St_Galler_FormenXVII" class="collapse" aria-labelledby="allCharterGroupTableSt_Galler_FormenXVII" data-parent="#St_Galler_FormenCharterGroupAccordion">
                                     <div class="card-body">
-                                        <table id="allCharterGroupTableXVII" class="table table-sm table-hover table-bordered" aria-label="{{ _('Gesamte Urkundengruppe') }} {{ _("Gruppe") }} XVII">
+                                        <table id="allCharterGroupTableSt_Galler_FormenXVII" class="table table-sm table-hover table-bordered" aria-label="{{ _("Tabelle") }}: St. Galler Formen  {{ _("Gruppe") }} XVII">
                                             <thead>
                                                 <tr>
                                                     <th id="all-charter-checkbox-column" scope="col"></th>
@@ -2192,17 +2192,17 @@
                                         </tr>
                                             </tbody>
                                         </table>
-                                        <button data-target="allCharterGroupTableXVII" class="btn btn-primary charter-select-button" type="button" aria-expanded="true">{{ _('Gewählte Urkunken lesen') }}</button>
+                                        <button data-target="allCharterGroupTableSt_Galler_FormenXVII" class="btn btn-primary charter-select-button" type="button" aria-expanded="true" disabled>{{ _('Gewählte Urkunken lesen') }}</button>
                                     </div>
                                 </div>
-                                <h3 class="card-header" id="part-allCharterGroups-XVIII">
-                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-XVIII" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-XVIII">
+                                <h3 class="card-header" id="part-allCharterGroups-St_Galler_FormenXVIII">
+                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-St_Galler_FormenXVIII" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-St_Galler_FormenXVIII">
                                     <h5>{{ _("Gruppe") }} XVIII</h5>
                                     </button>
                                 </h3>
-                                <div id="part-collapse-allCharterGroups-XVIII" class="collapse" aria-labelledby="allCharterGroupTableXVIII" data-parent="#St_Galler_FormenCharterGroupAccordion">
+                                <div id="part-collapse-allCharterGroups-St_Galler_FormenXVIII" class="collapse" aria-labelledby="allCharterGroupTableSt_Galler_FormenXVIII" data-parent="#St_Galler_FormenCharterGroupAccordion">
                                     <div class="card-body">
-                                        <table id="allCharterGroupTableXVIII" class="table table-sm table-hover table-bordered" aria-label="{{ _('Gesamte Urkundengruppe') }} {{ _("Gruppe") }} XVIII">
+                                        <table id="allCharterGroupTableSt_Galler_FormenXVIII" class="table table-sm table-hover table-bordered" aria-label="{{ _("Tabelle") }}: St. Galler Formen  {{ _("Gruppe") }} XVIII">
                                             <thead>
                                                 <tr>
                                                     <th id="all-charter-checkbox-column" scope="col"></th>
@@ -2244,17 +2244,17 @@
                                         </tr>
                                             </tbody>
                                         </table>
-                                        <button data-target="allCharterGroupTableXVIII" class="btn btn-primary charter-select-button" type="button" aria-expanded="true">{{ _('Gewählte Urkunken lesen') }}</button>
+                                        <button data-target="allCharterGroupTableSt_Galler_FormenXVIII" class="btn btn-primary charter-select-button" type="button" aria-expanded="true" disabled>{{ _('Gewählte Urkunken lesen') }}</button>
                                     </div>
                                 </div>
-                                <h3 class="card-header" id="part-allCharterGroups-XIX">
-                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-XIX" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-XIX">
+                                <h3 class="card-header" id="part-allCharterGroups-St_Galler_FormenXIX">
+                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-St_Galler_FormenXIX" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-St_Galler_FormenXIX">
                                     <h5>{{ _("Gruppe") }} XIX</h5>
                                     </button>
                                 </h3>
-                                <div id="part-collapse-allCharterGroups-XIX" class="collapse" aria-labelledby="allCharterGroupTableXIX" data-parent="#St_Galler_FormenCharterGroupAccordion">
+                                <div id="part-collapse-allCharterGroups-St_Galler_FormenXIX" class="collapse" aria-labelledby="allCharterGroupTableSt_Galler_FormenXIX" data-parent="#St_Galler_FormenCharterGroupAccordion">
                                     <div class="card-body">
-                                        <table id="allCharterGroupTableXIX" class="table table-sm table-hover table-bordered" aria-label="{{ _('Gesamte Urkundengruppe') }} {{ _("Gruppe") }} XIX">
+                                        <table id="allCharterGroupTableSt_Galler_FormenXIX" class="table table-sm table-hover table-bordered" aria-label="{{ _("Tabelle") }}: St. Galler Formen  {{ _("Gruppe") }} XIX">
                                             <thead>
                                                 <tr>
                                                     <th id="all-charter-checkbox-column" scope="col"></th>
@@ -2286,17 +2286,17 @@
                                         </tr>
                                             </tbody>
                                         </table>
-                                        <button data-target="allCharterGroupTableXIX" class="btn btn-primary charter-select-button" type="button" aria-expanded="true">{{ _('Gewählte Urkunken lesen') }}</button>
+                                        <button data-target="allCharterGroupTableSt_Galler_FormenXIX" class="btn btn-primary charter-select-button" type="button" aria-expanded="true" disabled>{{ _('Gewählte Urkunken lesen') }}</button>
                                     </div>
                                 </div>
-                                <h3 class="card-header" id="part-allCharterGroups-XX">
-                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-XX" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-XX">
+                                <h3 class="card-header" id="part-allCharterGroups-St_Galler_FormenXX">
+                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-St_Galler_FormenXX" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-St_Galler_FormenXX">
                                     <h5>{{ _("Gruppe") }} XX</h5>
                                     </button>
                                 </h3>
-                                <div id="part-collapse-allCharterGroups-XX" class="collapse" aria-labelledby="allCharterGroupTableXX" data-parent="#St_Galler_FormenCharterGroupAccordion">
+                                <div id="part-collapse-allCharterGroups-St_Galler_FormenXX" class="collapse" aria-labelledby="allCharterGroupTableSt_Galler_FormenXX" data-parent="#St_Galler_FormenCharterGroupAccordion">
                                     <div class="card-body">
-                                        <table id="allCharterGroupTableXX" class="table table-sm table-hover table-bordered" aria-label="{{ _('Gesamte Urkundengruppe') }} {{ _("Gruppe") }} XX">
+                                        <table id="allCharterGroupTableSt_Galler_FormenXX" class="table table-sm table-hover table-bordered" aria-label="{{ _("Tabelle") }}: St. Galler Formen  {{ _("Gruppe") }} XX">
                                             <thead>
                                                 <tr>
                                                     <th id="all-charter-checkbox-column" scope="col"></th>
@@ -2393,17 +2393,17 @@
                                         </tr>
                                             </tbody>
                                         </table>
-                                        <button data-target="allCharterGroupTableXX" class="btn btn-primary charter-select-button" type="button" aria-expanded="true">{{ _('Gewählte Urkunken lesen') }}</button>
+                                        <button data-target="allCharterGroupTableSt_Galler_FormenXX" class="btn btn-primary charter-select-button" type="button" aria-expanded="true" disabled>{{ _('Gewählte Urkunken lesen') }}</button>
                                     </div>
                                 </div>
-                                <h3 class="card-header" id="part-allCharterGroups-XXI">
-                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-XXI" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-XXI">
+                                <h3 class="card-header" id="part-allCharterGroups-St_Galler_FormenXXI">
+                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-St_Galler_FormenXXI" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-St_Galler_FormenXXI">
                                     <h5>{{ _("Gruppe") }} XXI</h5>
                                     </button>
                                 </h3>
-                                <div id="part-collapse-allCharterGroups-XXI" class="collapse" aria-labelledby="allCharterGroupTableXXI" data-parent="#St_Galler_FormenCharterGroupAccordion">
+                                <div id="part-collapse-allCharterGroups-St_Galler_FormenXXI" class="collapse" aria-labelledby="allCharterGroupTableSt_Galler_FormenXXI" data-parent="#St_Galler_FormenCharterGroupAccordion">
                                     <div class="card-body">
-                                        <table id="allCharterGroupTableXXI" class="table table-sm table-hover table-bordered" aria-label="{{ _('Gesamte Urkundengruppe') }} {{ _("Gruppe") }} XXI">
+                                        <table id="allCharterGroupTableSt_Galler_FormenXXI" class="table table-sm table-hover table-bordered" aria-label="{{ _("Tabelle") }}: St. Galler Formen  {{ _("Gruppe") }} XXI">
                                             <thead>
                                                 <tr>
                                                     <th id="all-charter-checkbox-column" scope="col"></th>
@@ -2435,17 +2435,17 @@
                                         </tr>
                                             </tbody>
                                         </table>
-                                        <button data-target="allCharterGroupTableXXI" class="btn btn-primary charter-select-button" type="button" aria-expanded="true">{{ _('Gewählte Urkunken lesen') }}</button>
+                                        <button data-target="allCharterGroupTableSt_Galler_FormenXXI" class="btn btn-primary charter-select-button" type="button" aria-expanded="true" disabled>{{ _('Gewählte Urkunken lesen') }}</button>
                                     </div>
                                 </div>
-                                <h3 class="card-header" id="part-allCharterGroups-XXII">
-                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-XXII" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-XXII">
+                                <h3 class="card-header" id="part-allCharterGroups-St_Galler_FormenXXII">
+                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-St_Galler_FormenXXII" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-St_Galler_FormenXXII">
                                     <h5>{{ _("Gruppe") }} XXII</h5>
                                     </button>
                                 </h3>
-                                <div id="part-collapse-allCharterGroups-XXII" class="collapse" aria-labelledby="allCharterGroupTableXXII" data-parent="#St_Galler_FormenCharterGroupAccordion">
+                                <div id="part-collapse-allCharterGroups-St_Galler_FormenXXII" class="collapse" aria-labelledby="allCharterGroupTableSt_Galler_FormenXXII" data-parent="#St_Galler_FormenCharterGroupAccordion">
                                     <div class="card-body">
-                                        <table id="allCharterGroupTableXXII" class="table table-sm table-hover table-bordered" aria-label="{{ _('Gesamte Urkundengruppe') }} {{ _("Gruppe") }} XXII">
+                                        <table id="allCharterGroupTableSt_Galler_FormenXXII" class="table table-sm table-hover table-bordered" aria-label="{{ _("Tabelle") }}: St. Galler Formen  {{ _("Gruppe") }} XXII">
                                             <thead>
                                                 <tr>
                                                     <th id="all-charter-checkbox-column" scope="col"></th>
@@ -2467,17 +2467,17 @@
                                         </tr>
                                             </tbody>
                                         </table>
-                                        <button data-target="allCharterGroupTableXXII" class="btn btn-primary charter-select-button" type="button" aria-expanded="true">{{ _('Gewählte Urkunken lesen') }}</button>
+                                        <button data-target="allCharterGroupTableSt_Galler_FormenXXII" class="btn btn-primary charter-select-button" type="button" aria-expanded="true" disabled>{{ _('Gewählte Urkunken lesen') }}</button>
                                     </div>
                                 </div>
-                                <h3 class="card-header" id="part-allCharterGroups-XXIII">
-                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-XXIII" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-XXIII">
+                                <h3 class="card-header" id="part-allCharterGroups-St_Galler_FormenXXIII">
+                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-St_Galler_FormenXXIII" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-St_Galler_FormenXXIII">
                                     <h5>{{ _("Gruppe") }} XXIII</h5>
                                     </button>
                                 </h3>
-                                <div id="part-collapse-allCharterGroups-XXIII" class="collapse" aria-labelledby="allCharterGroupTableXXIII" data-parent="#St_Galler_FormenCharterGroupAccordion">
+                                <div id="part-collapse-allCharterGroups-St_Galler_FormenXXIII" class="collapse" aria-labelledby="allCharterGroupTableSt_Galler_FormenXXIII" data-parent="#St_Galler_FormenCharterGroupAccordion">
                                     <div class="card-body">
-                                        <table id="allCharterGroupTableXXIII" class="table table-sm table-hover table-bordered" aria-label="{{ _('Gesamte Urkundengruppe') }} {{ _("Gruppe") }} XXIII">
+                                        <table id="allCharterGroupTableSt_Galler_FormenXXIII" class="table table-sm table-hover table-bordered" aria-label="{{ _("Tabelle") }}: St. Galler Formen  {{ _("Gruppe") }} XXIII">
                                             <thead>
                                                 <tr>
                                                     <th id="all-charter-checkbox-column" scope="col"></th>
@@ -2554,17 +2554,17 @@
                                         </tr>
                                             </tbody>
                                         </table>
-                                        <button data-target="allCharterGroupTableXXIII" class="btn btn-primary charter-select-button" type="button" aria-expanded="true">{{ _('Gewählte Urkunken lesen') }}</button>
+                                        <button data-target="allCharterGroupTableSt_Galler_FormenXXIII" class="btn btn-primary charter-select-button" type="button" aria-expanded="true" disabled>{{ _('Gewählte Urkunken lesen') }}</button>
                                     </div>
                                 </div>
-                                <h3 class="card-header" id="part-allCharterGroups-XXIV">
-                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-XXIV" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-XXIV">
+                                <h3 class="card-header" id="part-allCharterGroups-St_Galler_FormenXXIV">
+                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-St_Galler_FormenXXIV" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-St_Galler_FormenXXIV">
                                     <h5>{{ _("Gruppe") }} XXIV</h5>
                                     </button>
                                 </h3>
-                                <div id="part-collapse-allCharterGroups-XXIV" class="collapse" aria-labelledby="allCharterGroupTableXXIV" data-parent="#St_Galler_FormenCharterGroupAccordion">
+                                <div id="part-collapse-allCharterGroups-St_Galler_FormenXXIV" class="collapse" aria-labelledby="allCharterGroupTableSt_Galler_FormenXXIV" data-parent="#St_Galler_FormenCharterGroupAccordion">
                                     <div class="card-body">
-                                        <table id="allCharterGroupTableXXIV" class="table table-sm table-hover table-bordered" aria-label="{{ _('Gesamte Urkundengruppe') }} {{ _("Gruppe") }} XXIV">
+                                        <table id="allCharterGroupTableSt_Galler_FormenXXIV" class="table table-sm table-hover table-bordered" aria-label="{{ _("Tabelle") }}: St. Galler Formen  {{ _("Gruppe") }} XXIV">
                                             <thead>
                                                 <tr>
                                                     <th id="all-charter-checkbox-column" scope="col"></th>
@@ -2586,17 +2586,17 @@
                                         </tr>
                                             </tbody>
                                         </table>
-                                        <button data-target="allCharterGroupTableXXIV" class="btn btn-primary charter-select-button" type="button" aria-expanded="true">{{ _('Gewählte Urkunken lesen') }}</button>
+                                        <button data-target="allCharterGroupTableSt_Galler_FormenXXIV" class="btn btn-primary charter-select-button" type="button" aria-expanded="true" disabled>{{ _('Gewählte Urkunken lesen') }}</button>
                                     </div>
                                 </div>
-                                <h3 class="card-header" id="part-allCharterGroups-XXV">
-                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-XXV" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-XXV">
+                                <h3 class="card-header" id="part-allCharterGroups-St_Galler_FormenXXV">
+                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-St_Galler_FormenXXV" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-St_Galler_FormenXXV">
                                     <h5>{{ _("Gruppe") }} XXV</h5>
                                     </button>
                                 </h3>
-                                <div id="part-collapse-allCharterGroups-XXV" class="collapse" aria-labelledby="allCharterGroupTableXXV" data-parent="#St_Galler_FormenCharterGroupAccordion">
+                                <div id="part-collapse-allCharterGroups-St_Galler_FormenXXV" class="collapse" aria-labelledby="allCharterGroupTableSt_Galler_FormenXXV" data-parent="#St_Galler_FormenCharterGroupAccordion">
                                     <div class="card-body">
-                                        <table id="allCharterGroupTableXXV" class="table table-sm table-hover table-bordered" aria-label="{{ _('Gesamte Urkundengruppe') }} {{ _("Gruppe") }} XXV">
+                                        <table id="allCharterGroupTableSt_Galler_FormenXXV" class="table table-sm table-hover table-bordered" aria-label="{{ _("Tabelle") }}: St. Galler Formen  {{ _("Gruppe") }} XXV">
                                             <thead>
                                                 <tr>
                                                     <th id="all-charter-checkbox-column" scope="col"></th>
@@ -2618,17 +2618,17 @@
                                         </tr>
                                             </tbody>
                                         </table>
-                                        <button data-target="allCharterGroupTableXXV" class="btn btn-primary charter-select-button" type="button" aria-expanded="true">{{ _('Gewählte Urkunken lesen') }}</button>
+                                        <button data-target="allCharterGroupTableSt_Galler_FormenXXV" class="btn btn-primary charter-select-button" type="button" aria-expanded="true" disabled>{{ _('Gewählte Urkunken lesen') }}</button>
                                     </div>
                                 </div>
-                                <h3 class="card-header" id="part-allCharterGroups-XXVI">
-                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-XXVI" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-XXVI">
+                                <h3 class="card-header" id="part-allCharterGroups-St_Galler_FormenXXVI">
+                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-St_Galler_FormenXXVI" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-St_Galler_FormenXXVI">
                                     <h5>{{ _("Gruppe") }} XXVI</h5>
                                     </button>
                                 </h3>
-                                <div id="part-collapse-allCharterGroups-XXVI" class="collapse" aria-labelledby="allCharterGroupTableXXVI" data-parent="#St_Galler_FormenCharterGroupAccordion">
+                                <div id="part-collapse-allCharterGroups-St_Galler_FormenXXVI" class="collapse" aria-labelledby="allCharterGroupTableSt_Galler_FormenXXVI" data-parent="#St_Galler_FormenCharterGroupAccordion">
                                     <div class="card-body">
-                                        <table id="allCharterGroupTableXXVI" class="table table-sm table-hover table-bordered" aria-label="{{ _('Gesamte Urkundengruppe') }} {{ _("Gruppe") }} XXVI">
+                                        <table id="allCharterGroupTableSt_Galler_FormenXXVI" class="table table-sm table-hover table-bordered" aria-label="{{ _("Tabelle") }}: St. Galler Formen  {{ _("Gruppe") }} XXVI">
                                             <thead>
                                                 <tr>
                                                     <th id="all-charter-checkbox-column" scope="col"></th>
@@ -2660,17 +2660,17 @@
                                         </tr>
                                             </tbody>
                                         </table>
-                                        <button data-target="allCharterGroupTableXXVI" class="btn btn-primary charter-select-button" type="button" aria-expanded="true">{{ _('Gewählte Urkunken lesen') }}</button>
+                                        <button data-target="allCharterGroupTableSt_Galler_FormenXXVI" class="btn btn-primary charter-select-button" type="button" aria-expanded="true" disabled>{{ _('Gewählte Urkunken lesen') }}</button>
                                     </div>
                                 </div>
-                                <h3 class="card-header" id="part-allCharterGroups-XXVII">
-                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-XXVII" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-XXVII">
+                                <h3 class="card-header" id="part-allCharterGroups-St_Galler_FormenXXVII">
+                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-St_Galler_FormenXXVII" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-St_Galler_FormenXXVII">
                                     <h5>{{ _("Gruppe") }} XXVII</h5>
                                     </button>
                                 </h3>
-                                <div id="part-collapse-allCharterGroups-XXVII" class="collapse" aria-labelledby="allCharterGroupTableXXVII" data-parent="#St_Galler_FormenCharterGroupAccordion">
+                                <div id="part-collapse-allCharterGroups-St_Galler_FormenXXVII" class="collapse" aria-labelledby="allCharterGroupTableSt_Galler_FormenXXVII" data-parent="#St_Galler_FormenCharterGroupAccordion">
                                     <div class="card-body">
-                                        <table id="allCharterGroupTableXXVII" class="table table-sm table-hover table-bordered" aria-label="{{ _('Gesamte Urkundengruppe') }} {{ _("Gruppe") }} XXVII">
+                                        <table id="allCharterGroupTableSt_Galler_FormenXXVII" class="table table-sm table-hover table-bordered" aria-label="{{ _("Tabelle") }}: St. Galler Formen  {{ _("Gruppe") }} XXVII">
                                             <thead>
                                                 <tr>
                                                     <th id="all-charter-checkbox-column" scope="col"></th>
@@ -2757,17 +2757,17 @@
                                         </tr>
                                             </tbody>
                                         </table>
-                                        <button data-target="allCharterGroupTableXXVII" class="btn btn-primary charter-select-button" type="button" aria-expanded="true">{{ _('Gewählte Urkunken lesen') }}</button>
+                                        <button data-target="allCharterGroupTableSt_Galler_FormenXXVII" class="btn btn-primary charter-select-button" type="button" aria-expanded="true" disabled>{{ _('Gewählte Urkunken lesen') }}</button>
                                     </div>
                                 </div>
-                                <h3 class="card-header" id="part-allCharterGroups-XXVIII">
-                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-XXVIII" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-XXVIII">
+                                <h3 class="card-header" id="part-allCharterGroups-St_Galler_FormenXXVIII">
+                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-St_Galler_FormenXXVIII" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-St_Galler_FormenXXVIII">
                                     <h5>{{ _("Gruppe") }} XXVIII</h5>
                                     </button>
                                 </h3>
-                                <div id="part-collapse-allCharterGroups-XXVIII" class="collapse" aria-labelledby="allCharterGroupTableXXVIII" data-parent="#St_Galler_FormenCharterGroupAccordion">
+                                <div id="part-collapse-allCharterGroups-St_Galler_FormenXXVIII" class="collapse" aria-labelledby="allCharterGroupTableSt_Galler_FormenXXVIII" data-parent="#St_Galler_FormenCharterGroupAccordion">
                                     <div class="card-body">
-                                        <table id="allCharterGroupTableXXVIII" class="table table-sm table-hover table-bordered" aria-label="{{ _('Gesamte Urkundengruppe') }} {{ _("Gruppe") }} XXVIII">
+                                        <table id="allCharterGroupTableSt_Galler_FormenXXVIII" class="table table-sm table-hover table-bordered" aria-label="{{ _("Tabelle") }}: St. Galler Formen  {{ _("Gruppe") }} XXVIII">
                                             <thead>
                                                 <tr>
                                                     <th id="all-charter-checkbox-column" scope="col"></th>
@@ -2789,17 +2789,17 @@
                                         </tr>
                                             </tbody>
                                         </table>
-                                        <button data-target="allCharterGroupTableXXVIII" class="btn btn-primary charter-select-button" type="button" aria-expanded="true">{{ _('Gewählte Urkunken lesen') }}</button>
+                                        <button data-target="allCharterGroupTableSt_Galler_FormenXXVIII" class="btn btn-primary charter-select-button" type="button" aria-expanded="true" disabled>{{ _('Gewählte Urkunken lesen') }}</button>
                                     </div>
                                 </div>
-                                <h3 class="card-header" id="part-allCharterGroups-XXIX">
-                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-XXIX" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-XXIX">
+                                <h3 class="card-header" id="part-allCharterGroups-St_Galler_FormenXXIX">
+                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-St_Galler_FormenXXIX" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-St_Galler_FormenXXIX">
                                     <h5>{{ _("Gruppe") }} XXIX</h5>
                                     </button>
                                 </h3>
-                                <div id="part-collapse-allCharterGroups-XXIX" class="collapse" aria-labelledby="allCharterGroupTableXXIX" data-parent="#St_Galler_FormenCharterGroupAccordion">
+                                <div id="part-collapse-allCharterGroups-St_Galler_FormenXXIX" class="collapse" aria-labelledby="allCharterGroupTableSt_Galler_FormenXXIX" data-parent="#St_Galler_FormenCharterGroupAccordion">
                                     <div class="card-body">
-                                        <table id="allCharterGroupTableXXIX" class="table table-sm table-hover table-bordered" aria-label="{{ _('Gesamte Urkundengruppe') }} {{ _("Gruppe") }} XXIX">
+                                        <table id="allCharterGroupTableSt_Galler_FormenXXIX" class="table table-sm table-hover table-bordered" aria-label="{{ _("Tabelle") }}: St. Galler Formen  {{ _("Gruppe") }} XXIX">
                                             <thead>
                                                 <tr>
                                                     <th id="all-charter-checkbox-column" scope="col"></th>
@@ -2836,17 +2836,17 @@
                                         </tr>
                                             </tbody>
                                         </table>
-                                        <button data-target="allCharterGroupTableXXIX" class="btn btn-primary charter-select-button" type="button" aria-expanded="true">{{ _('Gewählte Urkunken lesen') }}</button>
+                                        <button data-target="allCharterGroupTableSt_Galler_FormenXXIX" class="btn btn-primary charter-select-button" type="button" aria-expanded="true" disabled>{{ _('Gewählte Urkunken lesen') }}</button>
                                     </div>
                                 </div>
-                                <h3 class="card-header" id="part-allCharterGroups-XXX">
-                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-XXX" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-XXX">
+                                <h3 class="card-header" id="part-allCharterGroups-St_Galler_FormenXXX">
+                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-St_Galler_FormenXXX" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-St_Galler_FormenXXX">
                                     <h5>{{ _("Gruppe") }} XXX</h5>
                                     </button>
                                 </h3>
-                                <div id="part-collapse-allCharterGroups-XXX" class="collapse" aria-labelledby="allCharterGroupTableXXX" data-parent="#St_Galler_FormenCharterGroupAccordion">
+                                <div id="part-collapse-allCharterGroups-St_Galler_FormenXXX" class="collapse" aria-labelledby="allCharterGroupTableSt_Galler_FormenXXX" data-parent="#St_Galler_FormenCharterGroupAccordion">
                                     <div class="card-body">
-                                        <table id="allCharterGroupTableXXX" class="table table-sm table-hover table-bordered" aria-label="{{ _('Gesamte Urkundengruppe') }} {{ _("Gruppe") }} XXX">
+                                        <table id="allCharterGroupTableSt_Galler_FormenXXX" class="table table-sm table-hover table-bordered" aria-label="{{ _("Tabelle") }}: St. Galler Formen  {{ _("Gruppe") }} XXX">
                                             <thead>
                                                 <tr>
                                                     <th id="all-charter-checkbox-column" scope="col"></th>
@@ -2878,17 +2878,17 @@
                                         </tr>
                                             </tbody>
                                         </table>
-                                        <button data-target="allCharterGroupTableXXX" class="btn btn-primary charter-select-button" type="button" aria-expanded="true">{{ _('Gewählte Urkunken lesen') }}</button>
+                                        <button data-target="allCharterGroupTableSt_Galler_FormenXXX" class="btn btn-primary charter-select-button" type="button" aria-expanded="true" disabled>{{ _('Gewählte Urkunken lesen') }}</button>
                                     </div>
                                 </div>
-                                <h3 class="card-header" id="part-allCharterGroups-XXXI">
-                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-XXXI" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-XXXI">
+                                <h3 class="card-header" id="part-allCharterGroups-St_Galler_FormenXXXI">
+                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-St_Galler_FormenXXXI" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-St_Galler_FormenXXXI">
                                     <h5>{{ _("Gruppe") }} XXXI</h5>
                                     </button>
                                 </h3>
-                                <div id="part-collapse-allCharterGroups-XXXI" class="collapse" aria-labelledby="allCharterGroupTableXXXI" data-parent="#St_Galler_FormenCharterGroupAccordion">
+                                <div id="part-collapse-allCharterGroups-St_Galler_FormenXXXI" class="collapse" aria-labelledby="allCharterGroupTableSt_Galler_FormenXXXI" data-parent="#St_Galler_FormenCharterGroupAccordion">
                                     <div class="card-body">
-                                        <table id="allCharterGroupTableXXXI" class="table table-sm table-hover table-bordered" aria-label="{{ _('Gesamte Urkundengruppe') }} {{ _("Gruppe") }} XXXI">
+                                        <table id="allCharterGroupTableSt_Galler_FormenXXXI" class="table table-sm table-hover table-bordered" aria-label="{{ _("Tabelle") }}: St. Galler Formen  {{ _("Gruppe") }} XXXI">
                                             <thead>
                                                 <tr>
                                                     <th id="all-charter-checkbox-column" scope="col"></th>
@@ -2910,17 +2910,17 @@
                                         </tr>
                                             </tbody>
                                         </table>
-                                        <button data-target="allCharterGroupTableXXXI" class="btn btn-primary charter-select-button" type="button" aria-expanded="true">{{ _('Gewählte Urkunken lesen') }}</button>
+                                        <button data-target="allCharterGroupTableSt_Galler_FormenXXXI" class="btn btn-primary charter-select-button" type="button" aria-expanded="true" disabled>{{ _('Gewählte Urkunken lesen') }}</button>
                                     </div>
                                 </div>
-                                <h3 class="card-header" id="part-allCharterGroups-XXXII">
-                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-XXXII" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-XXXII">
+                                <h3 class="card-header" id="part-allCharterGroups-St_Galler_FormenXXXII">
+                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-St_Galler_FormenXXXII" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-St_Galler_FormenXXXII">
                                     <h5>{{ _("Gruppe") }} XXXII</h5>
                                     </button>
                                 </h3>
-                                <div id="part-collapse-allCharterGroups-XXXII" class="collapse" aria-labelledby="allCharterGroupTableXXXII" data-parent="#St_Galler_FormenCharterGroupAccordion">
+                                <div id="part-collapse-allCharterGroups-St_Galler_FormenXXXII" class="collapse" aria-labelledby="allCharterGroupTableSt_Galler_FormenXXXII" data-parent="#St_Galler_FormenCharterGroupAccordion">
                                     <div class="card-body">
-                                        <table id="allCharterGroupTableXXXII" class="table table-sm table-hover table-bordered" aria-label="{{ _('Gesamte Urkundengruppe') }} {{ _("Gruppe") }} XXXII">
+                                        <table id="allCharterGroupTableSt_Galler_FormenXXXII" class="table table-sm table-hover table-bordered" aria-label="{{ _("Tabelle") }}: St. Galler Formen  {{ _("Gruppe") }} XXXII">
                                             <thead>
                                                 <tr>
                                                     <th id="all-charter-checkbox-column" scope="col"></th>
@@ -2972,17 +2972,17 @@
                                         </tr>
                                             </tbody>
                                         </table>
-                                        <button data-target="allCharterGroupTableXXXII" class="btn btn-primary charter-select-button" type="button" aria-expanded="true">{{ _('Gewählte Urkunken lesen') }}</button>
+                                        <button data-target="allCharterGroupTableSt_Galler_FormenXXXII" class="btn btn-primary charter-select-button" type="button" aria-expanded="true" disabled>{{ _('Gewählte Urkunken lesen') }}</button>
                                     </div>
                                 </div>
-                                <h3 class="card-header" id="part-allCharterGroups-XXXIII">
-                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-XXXIII" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-XXXIII">
+                                <h3 class="card-header" id="part-allCharterGroups-St_Galler_FormenXXXIII">
+                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-St_Galler_FormenXXXIII" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-St_Galler_FormenXXXIII">
                                     <h5>{{ _("Gruppe") }} XXXIII</h5>
                                     </button>
                                 </h3>
-                                <div id="part-collapse-allCharterGroups-XXXIII" class="collapse" aria-labelledby="allCharterGroupTableXXXIII" data-parent="#St_Galler_FormenCharterGroupAccordion">
+                                <div id="part-collapse-allCharterGroups-St_Galler_FormenXXXIII" class="collapse" aria-labelledby="allCharterGroupTableSt_Galler_FormenXXXIII" data-parent="#St_Galler_FormenCharterGroupAccordion">
                                     <div class="card-body">
-                                        <table id="allCharterGroupTableXXXIII" class="table table-sm table-hover table-bordered" aria-label="{{ _('Gesamte Urkundengruppe') }} {{ _("Gruppe") }} XXXIII">
+                                        <table id="allCharterGroupTableSt_Galler_FormenXXXIII" class="table table-sm table-hover table-bordered" aria-label="{{ _("Tabelle") }}: St. Galler Formen  {{ _("Gruppe") }} XXXIII">
                                             <thead>
                                                 <tr>
                                                     <th id="all-charter-checkbox-column" scope="col"></th>
@@ -3019,17 +3019,17 @@
                                         </tr>
                                             </tbody>
                                         </table>
-                                        <button data-target="allCharterGroupTableXXXIII" class="btn btn-primary charter-select-button" type="button" aria-expanded="true">{{ _('Gewählte Urkunken lesen') }}</button>
+                                        <button data-target="allCharterGroupTableSt_Galler_FormenXXXIII" class="btn btn-primary charter-select-button" type="button" aria-expanded="true" disabled>{{ _('Gewählte Urkunken lesen') }}</button>
                                     </div>
                                 </div>
-                                <h3 class="card-header" id="part-allCharterGroups-XXXIV">
-                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-XXXIV" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-XXXIV">
+                                <h3 class="card-header" id="part-allCharterGroups-St_Galler_FormenXXXIV">
+                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-St_Galler_FormenXXXIV" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-St_Galler_FormenXXXIV">
                                     <h5>{{ _("Gruppe") }} XXXIV</h5>
                                     </button>
                                 </h3>
-                                <div id="part-collapse-allCharterGroups-XXXIV" class="collapse" aria-labelledby="allCharterGroupTableXXXIV" data-parent="#St_Galler_FormenCharterGroupAccordion">
+                                <div id="part-collapse-allCharterGroups-St_Galler_FormenXXXIV" class="collapse" aria-labelledby="allCharterGroupTableSt_Galler_FormenXXXIV" data-parent="#St_Galler_FormenCharterGroupAccordion">
                                     <div class="card-body">
-                                        <table id="allCharterGroupTableXXXIV" class="table table-sm table-hover table-bordered" aria-label="{{ _('Gesamte Urkundengruppe') }} {{ _("Gruppe") }} XXXIV">
+                                        <table id="allCharterGroupTableSt_Galler_FormenXXXIV" class="table table-sm table-hover table-bordered" aria-label="{{ _("Tabelle") }}: St. Galler Formen  {{ _("Gruppe") }} XXXIV">
                                             <thead>
                                                 <tr>
                                                     <th id="all-charter-checkbox-column" scope="col"></th>
@@ -3051,17 +3051,17 @@
                                         </tr>
                                             </tbody>
                                         </table>
-                                        <button data-target="allCharterGroupTableXXXIV" class="btn btn-primary charter-select-button" type="button" aria-expanded="true">{{ _('Gewählte Urkunken lesen') }}</button>
+                                        <button data-target="allCharterGroupTableSt_Galler_FormenXXXIV" class="btn btn-primary charter-select-button" type="button" aria-expanded="true" disabled>{{ _('Gewählte Urkunken lesen') }}</button>
                                     </div>
                                 </div>
-                                <h3 class="card-header" id="part-allCharterGroups-XXXV">
-                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-XXXV" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-XXXV">
+                                <h3 class="card-header" id="part-allCharterGroups-St_Galler_FormenXXXV">
+                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-St_Galler_FormenXXXV" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-St_Galler_FormenXXXV">
                                     <h5>{{ _("Gruppe") }} XXXV</h5>
                                     </button>
                                 </h3>
-                                <div id="part-collapse-allCharterGroups-XXXV" class="collapse" aria-labelledby="allCharterGroupTableXXXV" data-parent="#St_Galler_FormenCharterGroupAccordion">
+                                <div id="part-collapse-allCharterGroups-St_Galler_FormenXXXV" class="collapse" aria-labelledby="allCharterGroupTableSt_Galler_FormenXXXV" data-parent="#St_Galler_FormenCharterGroupAccordion">
                                     <div class="card-body">
-                                        <table id="allCharterGroupTableXXXV" class="table table-sm table-hover table-bordered" aria-label="{{ _('Gesamte Urkundengruppe') }} {{ _("Gruppe") }} XXXV">
+                                        <table id="allCharterGroupTableSt_Galler_FormenXXXV" class="table table-sm table-hover table-bordered" aria-label="{{ _("Tabelle") }}: St. Galler Formen  {{ _("Gruppe") }} XXXV">
                                             <thead>
                                                 <tr>
                                                     <th id="all-charter-checkbox-column" scope="col"></th>
@@ -3088,17 +3088,17 @@
                                         </tr>
                                             </tbody>
                                         </table>
-                                        <button data-target="allCharterGroupTableXXXV" class="btn btn-primary charter-select-button" type="button" aria-expanded="true">{{ _('Gewählte Urkunken lesen') }}</button>
+                                        <button data-target="allCharterGroupTableSt_Galler_FormenXXXV" class="btn btn-primary charter-select-button" type="button" aria-expanded="true" disabled>{{ _('Gewählte Urkunken lesen') }}</button>
                                     </div>
                                 </div>
-                                <h3 class="card-header" id="part-allCharterGroups-XXXVI">
-                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-XXXVI" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-XXXVI">
+                                <h3 class="card-header" id="part-allCharterGroups-St_Galler_FormenXXXVI">
+                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-St_Galler_FormenXXXVI" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-St_Galler_FormenXXXVI">
                                     <h5>{{ _("Gruppe") }} XXXVI</h5>
                                     </button>
                                 </h3>
-                                <div id="part-collapse-allCharterGroups-XXXVI" class="collapse" aria-labelledby="allCharterGroupTableXXXVI" data-parent="#St_Galler_FormenCharterGroupAccordion">
+                                <div id="part-collapse-allCharterGroups-St_Galler_FormenXXXVI" class="collapse" aria-labelledby="allCharterGroupTableSt_Galler_FormenXXXVI" data-parent="#St_Galler_FormenCharterGroupAccordion">
                                     <div class="card-body">
-                                        <table id="allCharterGroupTableXXXVI" class="table table-sm table-hover table-bordered" aria-label="{{ _('Gesamte Urkundengruppe') }} {{ _("Gruppe") }} XXXVI">
+                                        <table id="allCharterGroupTableSt_Galler_FormenXXXVI" class="table table-sm table-hover table-bordered" aria-label="{{ _("Tabelle") }}: St. Galler Formen  {{ _("Gruppe") }} XXXVI">
                                             <thead>
                                                 <tr>
                                                     <th id="all-charter-checkbox-column" scope="col"></th>
@@ -3125,17 +3125,17 @@
                                         </tr>
                                             </tbody>
                                         </table>
-                                        <button data-target="allCharterGroupTableXXXVI" class="btn btn-primary charter-select-button" type="button" aria-expanded="true">{{ _('Gewählte Urkunken lesen') }}</button>
+                                        <button data-target="allCharterGroupTableSt_Galler_FormenXXXVI" class="btn btn-primary charter-select-button" type="button" aria-expanded="true" disabled>{{ _('Gewählte Urkunken lesen') }}</button>
                                     </div>
                                 </div>
-                                <h3 class="card-header" id="part-allCharterGroups-XXXVII">
-                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-XXXVII" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-XXXVII">
+                                <h3 class="card-header" id="part-allCharterGroups-St_Galler_FormenXXXVII">
+                                    <button class="btn btn-link btn-block text-left" type="button" data-toggle="collapse" data-target="#part-collapse-allCharterGroups-St_Galler_FormenXXXVII" aria-expanded="true" aria-controls="part-collapse-allCharterGroups-St_Galler_FormenXXXVII">
                                     <h5>{{ _("Gruppe") }} XXXVII</h5>
                                     </button>
                                 </h3>
-                                <div id="part-collapse-allCharterGroups-XXXVII" class="collapse" aria-labelledby="allCharterGroupTableXXXVII" data-parent="#St_Galler_FormenCharterGroupAccordion">
+                                <div id="part-collapse-allCharterGroups-St_Galler_FormenXXXVII" class="collapse" aria-labelledby="allCharterGroupTableSt_Galler_FormenXXXVII" data-parent="#St_Galler_FormenCharterGroupAccordion">
                                     <div class="card-body">
-                                        <table id="allCharterGroupTableXXXVII" class="table table-sm table-hover table-bordered" aria-label="{{ _('Gesamte Urkundengruppe') }} {{ _("Gruppe") }} XXXVII">
+                                        <table id="allCharterGroupTableSt_Galler_FormenXXXVII" class="table table-sm table-hover table-bordered" aria-label="{{ _("Tabelle") }}: St. Galler Formen  {{ _("Gruppe") }} XXXVII">
                                             <thead>
                                                 <tr>
                                                     <th id="all-charter-checkbox-column" scope="col"></th>
@@ -3157,7 +3157,7 @@
                                         </tr>
                                             </tbody>
                                         </table>
-                                        <button data-target="allCharterGroupTableXXXVII" class="btn btn-primary charter-select-button" type="button" aria-expanded="true">{{ _('Gewählte Urkunken lesen') }}</button>
+                                        <button data-target="allCharterGroupTableSt_Galler_FormenXXXVII" class="btn btn-primary charter-select-button" type="button" aria-expanded="true" disabled>{{ _('Gewählte Urkunken lesen') }}</button>
                                     </div>
                                 </div>
                         </div>


### PR DESCRIPTION
- The button to show charters in the reading pane in the Urkundengruppen view is now disabled until at least one checkbox is checked
- User can filter the charter parts tables according to the charter type (e.g., Tausch)